### PR TITLE
Implement preview pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ up = "k"
 down = "j"
 select = "space"
 export = "ctrl+e"
+
+[preview]
+theme = "dracula"
+max_lines = 400
+load_more_step = 200
 ```
 
 ## CI

--- a/crates/llmctx/assets/themes/dracula.tmTheme
+++ b/crates/llmctx/assets/themes/dracula.tmTheme
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Dracula</string>
+    <key>settings</key>
+    <array>
+        <dict>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#282a36</string>
+                <key>caret</key>
+                <string>#f8f8f0</string>
+                <key>foreground</key>
+                <string>#f8f8f2</string>
+                <key>selection</key>
+                <string>#44475a</string>
+            </dict>
+        </dict>
+    </array>
+    <key>uuid</key>
+    <string>CFAD909A-66D3-4039-90F7-D113402E3472</string>
+</dict>
+</plist>

--- a/crates/llmctx/src/app/mod.rs
+++ b/crates/llmctx/src/app/mod.rs
@@ -1,6 +1,7 @@
 //! Application layer orchestrating domain logic and infrastructure.
 
 pub mod export;
+pub mod preview;
 pub mod scan;
 pub mod search;
 pub mod selection;

--- a/crates/llmctx/src/app/preview.rs
+++ b/crates/llmctx/src/app/preview.rs
@@ -1,0 +1,270 @@
+//! Preview service producing syntax highlighted, chunked views of files.
+
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::infra::config::Config;
+use crate::infra::highlight::{HighlightResult, Highlighter};
+
+/// Default continuation size when previewing large files if configuration is zero.
+const DEFAULT_CHUNK_SIZE: usize = 200;
+
+/// A continuation token used for loading more preview content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContinuationToken {
+    pub start_line: usize,
+}
+
+/// Displayable preview output including metadata for the UI layer.
+#[derive(Debug, Clone)]
+pub struct PreviewSegment {
+    pub path: PathBuf,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub highlighted: HighlightResult,
+    pub truncated: bool,
+    pub continuation: Option<ContinuationToken>,
+    pub notice: Option<String>,
+}
+
+/// Service responsible for preparing preview data from files.
+#[derive(Debug, Default)]
+pub struct PreviewService {
+    highlighter: Highlighter,
+}
+
+impl PreviewService {
+    pub fn new() -> Self {
+        Self {
+            highlighter: Highlighter::new(),
+        }
+    }
+
+    /// Load a preview segment for the provided path.
+    pub fn preview(
+        &self,
+        path: &Path,
+        range: Option<std::ops::Range<usize>>,
+        config: &Config,
+    ) -> Result<PreviewSegment> {
+        if !path.exists() {
+            return Err(anyhow!("file not found: {}", path.display()));
+        }
+
+        let start = range.as_ref().map_or(0, |r| r.start);
+
+        if Self::is_binary(path)? {
+            let message = format!(
+                "Binary preview not available for {} (rendered as plain text).",
+                path.display()
+            );
+            let theme = config.defaults.theme().to_string();
+            let highlighted = HighlightResult::plain(Vec::new(), theme);
+            return Ok(PreviewSegment {
+                path: path.to_path_buf(),
+                start_line: start + 1,
+                end_line: start,
+                truncated: false,
+                continuation: None,
+                notice: Some(message),
+                highlighted,
+            });
+        }
+
+        let configured_chunk = config.defaults.preview_max_lines();
+        let chunk_size = if configured_chunk == 0 {
+            DEFAULT_CHUNK_SIZE
+        } else {
+            configured_chunk
+        };
+
+        let limit = range
+            .as_ref()
+            .map(|r| r.end.saturating_sub(r.start))
+            .filter(|len| *len > 0)
+            .unwrap_or(chunk_size);
+
+        let (lines, lossy, has_more) = Self::read_lines(path, start, limit)?;
+        let mut notice = None;
+        let theme_name = config.defaults.theme().to_string();
+
+        let highlighted = if lossy {
+            notice =
+                Some("Preview rendered without syntax highlighting due to invalid UTF-8.".into());
+            HighlightResult::plain(lines.clone(), theme_name)
+        } else {
+            self.highlighter
+                .highlight(path, &lines, config.defaults.theme())
+        };
+
+        let end_line = start + lines.len();
+        let continuation = has_more.then(|| ContinuationToken {
+            start_line: start + lines.len(),
+        });
+
+        Ok(PreviewSegment {
+            path: path.to_path_buf(),
+            start_line: start + 1,
+            end_line,
+            truncated: has_more,
+            highlighted,
+            continuation,
+            notice,
+        })
+    }
+
+    /// Determine if the file should be treated as binary and skipped.
+    fn is_binary(path: &Path) -> Result<bool> {
+        let mut file = File::open(path)?;
+        let mut buf = [0u8; 1024];
+        let read = file.read(&mut buf)?;
+        Ok(buf[..read].contains(&0))
+    }
+
+    fn read_lines(
+        path: &Path,
+        start: usize,
+        max_lines: usize,
+    ) -> Result<(Vec<String>, bool, bool)> {
+        let file =
+            File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut raw = Vec::new();
+        let mut lines = Vec::new();
+        let mut lossy = false;
+        let mut reached_eof = false;
+        let mut index = 0;
+
+        while index < start + max_lines {
+            raw.clear();
+            let bytes = reader.read_until(b'\n', &mut raw)?;
+            if bytes == 0 {
+                reached_eof = true;
+                break;
+            }
+
+            if index >= start && lines.len() < max_lines {
+                if raw.ends_with(&[b'\n']) {
+                    raw.pop();
+                    if raw.ends_with(&[b'\r']) {
+                        raw.pop();
+                    }
+                }
+                let text = String::from_utf8_lossy(&raw);
+                if matches!(text, Cow::Owned(_)) {
+                    lossy = true;
+                }
+                lines.push(text.into_owned());
+            }
+
+            index += 1;
+            if lines.len() >= max_lines {
+                break;
+            }
+        }
+
+        let mut has_more = false;
+        if !reached_eof && lines.len() == max_lines {
+            let mut peek = [0u8; 1];
+            has_more = reader.read(&mut peek)? > 0;
+        }
+
+        Ok((lines, lossy, has_more))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+    use crate::infra::highlight::HighlightMode;
+
+    fn config() -> Config {
+        Config::default()
+    }
+
+    #[test]
+    fn preview_small_file_returns_highlighted_segment() -> Result<()> {
+        let dir = tempdir()?;
+        let file = dir.path().join("hello.rs");
+        std::fs::write(&file, "fn greet() { println!(\"hi\"); }\n")?;
+
+        let service = PreviewService::new();
+        let segment = service.preview(&file, None, &config())?;
+
+        assert_eq!(segment.start_line, 1);
+        assert_eq!(segment.end_line, 1);
+        assert_eq!(segment.highlighted.mode, HighlightMode::Highlighted);
+        assert!(segment.notice.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn preview_handles_range() -> Result<()> {
+        let dir = tempdir()?;
+        let file = dir.path().join("example.rs");
+        let content = (0..500)
+            .map(|i| format!("fn foo{i}() {{}}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&file, content)?;
+
+        let service = PreviewService::new();
+        let config = Config::default();
+        let segment = service.preview(&file, Some(100..150), &config)?;
+
+        assert_eq!(segment.start_line, 101);
+        assert_eq!(segment.end_line, 150);
+        assert!(segment.truncated);
+        assert!(segment.continuation.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn binary_file_returns_notice() -> Result<()> {
+        let dir = tempdir()?;
+        let file = dir.path().join("data.bin");
+        std::fs::write(&file, [0, 159, 146, 150])?;
+
+        let service = PreviewService::new();
+        let segment = service.preview(&file, None, &config())?;
+
+        assert_eq!(segment.highlighted.mode, HighlightMode::Plain);
+        assert!(segment.highlighted.lines.is_empty());
+        assert!(
+            segment
+                .notice
+                .as_ref()
+                .is_some_and(|n| n.contains("Binary preview"))
+        );
+        assert!(!segment.truncated);
+        Ok(())
+    }
+
+    #[test]
+    fn lossy_content_falls_back_to_plain() -> Result<()> {
+        let dir = tempdir()?;
+        let file = dir.path().join("lossy.txt");
+        let mut handle = File::create(&file)?;
+        handle.write_all(b"hello\xffworld\n")?;
+        drop(handle);
+
+        let service = PreviewService::new();
+        let segment = service.preview(&file, None, &config())?;
+
+        assert_eq!(segment.highlighted.mode, HighlightMode::Plain);
+        assert!(
+            segment
+                .notice
+                .as_ref()
+                .is_some_and(|n| n.contains("invalid UTF-8"))
+        );
+        assert_eq!(segment.end_line, 1);
+        Ok(())
+    }
+}

--- a/crates/llmctx/src/app/preview.rs
+++ b/crates/llmctx/src/app/preview.rs
@@ -148,9 +148,9 @@ impl PreviewService {
             }
 
             if index >= start && lines.len() < max_lines {
-                if raw.ends_with(&[b'\n']) {
+                if raw.ends_with(b"\n") {
                     raw.pop();
-                    if raw.ends_with(&[b'\r']) {
+                    if raw.ends_with(b"\r") {
                         raw.pop();
                     }
                 }

--- a/crates/llmctx/src/app/preview.rs
+++ b/crates/llmctx/src/app/preview.rs
@@ -180,9 +180,9 @@ impl PreviewService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::infra::highlight::HighlightMode;
     use std::io::Write;
     use tempfile::tempdir;
-    use crate::infra::highlight::HighlightMode;
 
     fn config() -> Config {
         Config::default()

--- a/crates/llmctx/src/infra/highlight.rs
+++ b/crates/llmctx/src/infra/highlight.rs
@@ -1,10 +1,319 @@
-//! Syntax highlighting utilities.
+//! Syntax highlighting utilities built on top of syntect.
 
-#[derive(Default)]
-pub struct Highlighter;
+use std::borrow::Cow;
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use once_cell::sync::Lazy;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{FontStyle, Style as SyntectStyle, Theme, ThemeSet};
+use syntect::parsing::{SyntaxReference, SyntaxSet};
+
+const DEFAULT_THEME: &str = "base16-ocean.dark";
+
+static DEFAULT_ASSETS: Lazy<(Arc<SyntaxSet>, Arc<ThemeSet>)> = Lazy::new(|| {
+    let syntax_set = SyntaxSet::load_defaults_newlines();
+    let mut theme_set = ThemeSet::load_defaults();
+
+    for (name, source) in EMBEDDED_THEMES {
+        if theme_set.themes.contains_key(*name) {
+            continue;
+        }
+        let mut cursor = Cursor::new(source);
+        match ThemeSet::load_from_reader(&mut cursor) {
+            Ok(theme) => {
+                theme_set.themes.insert((*name).to_string(), theme);
+            }
+            Err(err) => {
+                tracing::warn!(theme = %name, error = %err, "failed to load embedded theme");
+            }
+        }
+    }
+
+    (Arc::new(syntax_set), Arc::new(theme_set))
+});
+
+/// Embedded themes bundled with the binary.
+static EMBEDDED_THEMES: &[(&str, &str)] = &[(
+    "dracula",
+    include_str!("../../assets/themes/dracula.tmTheme"),
+)];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RgbColor {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HighlightAttributes {
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HighlightStyle {
+    pub foreground: Option<RgbColor>,
+    pub background: Option<RgbColor>,
+    pub attributes: HighlightAttributes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightSpan {
+    pub content: String,
+    pub style: HighlightStyle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightLine {
+    pub spans: Vec<HighlightSpan>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HighlightMode {
+    Highlighted,
+    Plain,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightResult {
+    pub lines: Vec<HighlightLine>,
+    pub language: Option<String>,
+    pub theme: String,
+    pub mode: HighlightMode,
+}
+
+impl HighlightResult {
+    pub fn plain(lines: Vec<String>, theme: String) -> Self {
+        HighlightResult {
+            lines: lines
+                .into_iter()
+                .map(|line| HighlightLine {
+                    spans: vec![HighlightSpan {
+                        content: line,
+                        style: HighlightStyle::default(),
+                    }],
+                })
+                .collect(),
+            language: None,
+            theme,
+            mode: HighlightMode::Plain,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Highlighter {
+    syntax_set: Arc<SyntaxSet>,
+    theme_set: Arc<ThemeSet>,
+}
+
+impl Default for Highlighter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Highlighter {
     pub fn new() -> Self {
-        Self
+        let assets = &*DEFAULT_ASSETS;
+        Self {
+            syntax_set: Arc::clone(&assets.0),
+            theme_set: Arc::clone(&assets.1),
+        }
+    }
+
+    pub fn available_themes(&self) -> Vec<String> {
+        let mut themes: Vec<_> = self.theme_set.themes.keys().cloned().collect();
+        themes.sort();
+        themes
+    }
+
+    pub fn highlight(&self, path: &Path, lines: &[String], theme: &str) -> HighlightResult {
+        let resolved_theme = self.resolve_theme(theme);
+        let theme_name = resolved_theme.name.to_string();
+
+        if let Some((syntax, language)) = self.syntax_for_path(path) {
+            match self.highlight_with_syntax(lines, resolved_theme.theme, syntax) {
+                Ok(highlighted) => HighlightResult {
+                    lines: highlighted,
+                    language: Some(language),
+                    theme: theme_name,
+                    mode: HighlightMode::Highlighted,
+                },
+                Err(err) => {
+                    tracing::warn!(error = %err, path = %path.display(), "highlight failed");
+                    HighlightResult::plain(lines.to_vec(), theme_name)
+                }
+            }
+        } else {
+            HighlightResult::plain(lines.to_vec(), theme_name)
+        }
+    }
+
+    fn highlight_with_syntax(
+        &self,
+        lines: &[String],
+        theme: &Theme,
+        syntax: &SyntaxReference,
+    ) -> Result<Vec<HighlightLine>> {
+        let mut highlighter = HighlightLines::new(syntax, theme);
+        let mut result = Vec::with_capacity(lines.len());
+        for line in lines {
+            let segments = highlighter.highlight_line(line, &self.syntax_set)?;
+            let spans = segments
+                .into_iter()
+                .map(|(style, text)| HighlightSpan {
+                    content: text.to_string(),
+                    style: convert_style(style),
+                })
+                .collect();
+            result.push(HighlightLine { spans });
+        }
+        Ok(result)
+    }
+
+    fn syntax_for_path(&self, path: &Path) -> Option<(&SyntaxReference, String)> {
+        match self.syntax_set.find_syntax_for_file(path) {
+            Ok(Some(syntax)) => Some((syntax, syntax.name.clone())),
+            Ok(None) => None,
+            Err(err) => {
+                tracing::debug!(path = %path.display(), error = %err, "syntax lookup failed");
+                None
+            }
+        }
+    }
+
+    fn resolve_theme<'a>(&'a self, requested: &'a str) -> ResolvedTheme<'a> {
+        if let Some(theme) = self.theme_set.themes.get(requested) {
+            return ResolvedTheme {
+                name: Cow::Borrowed(requested),
+                theme,
+            };
+        }
+
+        if let Some(name) = self
+            .theme_set
+            .themes
+            .keys()
+            .find(|name| name.eq_ignore_ascii_case(requested))
+            .cloned()
+        {
+            if let Some(theme) = self.theme_set.themes.get(&name) {
+                return ResolvedTheme {
+                    name: Cow::Owned(name),
+                    theme,
+                };
+            }
+        }
+
+        let fallback_name = if self.theme_set.themes.contains_key(DEFAULT_THEME) {
+            DEFAULT_THEME.to_string()
+        } else {
+            self.theme_set
+                .themes
+                .keys()
+                .next()
+                .cloned()
+                .unwrap_or_else(|| DEFAULT_THEME.to_string())
+        };
+
+        let theme = self
+            .theme_set
+            .themes
+            .get(&fallback_name)
+            .expect("fallback theme must exist");
+
+        tracing::warn!(
+            requested,
+            fallback = %fallback_name,
+            "theme not found"
+        );
+
+        ResolvedTheme {
+            name: Cow::Owned(fallback_name),
+            theme,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedTheme<'a> {
+    name: Cow<'a, str>,
+    theme: &'a Theme,
+}
+
+fn convert_style(style: SyntectStyle) -> HighlightStyle {
+    let attributes = HighlightAttributes {
+        bold: style.font_style.contains(FontStyle::BOLD),
+        italic: style.font_style.contains(FontStyle::ITALIC),
+        underline: style.font_style.contains(FontStyle::UNDERLINE),
+    };
+
+    HighlightStyle {
+        foreground: convert_color(style.foreground),
+        background: convert_color(style.background),
+        attributes,
+    }
+}
+
+fn convert_color(color: syntect::highlighting::Color) -> Option<RgbColor> {
+    if color.a == 0 {
+        None
+    } else {
+        Some(RgbColor {
+            r: color.r,
+            g: color.g,
+            b: color.b,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn dracula_theme_is_available() {
+        let highlighter = Highlighter::new();
+        assert!(
+            highlighter
+                .available_themes()
+                .iter()
+                .any(|theme| theme.eq_ignore_ascii_case("dracula"))
+        );
+    }
+
+    #[test]
+    fn highlight_rust_file_produces_segments() -> Result<()> {
+        let dir = tempdir()?;
+        let file = dir.path().join("sample.rs");
+        fs::write(&file, "fn main() { println!(\"hi\"); }\n")?;
+
+        let highlighter = Highlighter::new();
+        let lines = vec!["fn main() { println!(\"hi\"); }".to_string()];
+        let result = highlighter.highlight(&file, &lines, "dracula");
+
+        assert_eq!(result.lines.len(), 1);
+        assert!(!result.lines[0].spans.is_empty());
+        assert_eq!(result.mode, HighlightMode::Highlighted);
+        assert_eq!(result.language.as_deref(), Some("Rust"));
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_theme_falls_back() {
+        let highlighter = Highlighter::new();
+        let lines = vec!["plain text".to_string()];
+        let file = Path::new("plain.txt");
+        let result = highlighter.highlight(file, &lines, "not-a-theme");
+        assert_eq!(result.mode, HighlightMode::Highlighted);
+        assert_ne!(result.theme, "not-a-theme");
     }
 }

--- a/crates/llmctx/src/infra/highlight.rs
+++ b/crates/llmctx/src/infra/highlight.rs
@@ -196,19 +196,18 @@ impl Highlighter {
             };
         }
 
-        if let Some(name) = self
+        if let Some((name, theme)) = self
             .theme_set
             .themes
             .keys()
             .find(|name| name.eq_ignore_ascii_case(requested))
             .cloned()
+            .and_then(|name| self.theme_set.themes.get(&name).map(|theme| (name, theme)))
         {
-            if let Some(theme) = self.theme_set.themes.get(&name) {
-                return ResolvedTheme {
-                    name: Cow::Owned(name),
-                    theme,
-                };
-            }
+            return ResolvedTheme {
+                name: Cow::Owned(name),
+                theme,
+            };
         }
 
         let fallback_name = if self.theme_set.themes.contains_key(DEFAULT_THEME) {

--- a/crates/llmctx/src/ui/components/preview.rs
+++ b/crates/llmctx/src/ui/components/preview.rs
@@ -1,6 +1,94 @@
-//! Preview component placeholder.
+//! Preview component rendering highlighted file segments.
 
-#[derive(Default)]
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use crate::app::preview::PreviewSegment;
+use crate::infra::highlight::HighlightSpan;
+
+/// Ratatui component responsible for displaying file previews with line numbers.
+#[derive(Debug, Default)]
 pub struct Preview;
 
-impl Preview {}
+impl Preview {
+    pub fn render(&self, segment: &PreviewSegment, area: Rect, buf: &mut Buffer) {
+        let title = format!(
+            "{} ({}-{})",
+            segment.path.display(),
+            segment.start_line,
+            segment.end_line
+        );
+
+        let block = Block::default().title(title).borders(Borders::ALL);
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        let mut lines = Vec::with_capacity(segment.highlighted.lines.len());
+        for (idx, line) in segment.highlighted.lines.iter().enumerate() {
+            let line_number = segment.start_line + idx;
+            let prefix = format!("{:>4} │ ", line_number);
+            let mut spans = vec![Span::styled(prefix, Style::default().fg(Color::DarkGray))];
+            spans.extend(line.spans.iter().map(highlight_span_to_span));
+            lines.push(Line::from(spans));
+        }
+
+        if let Some(notice) = &segment.notice {
+            lines.insert(
+                0,
+                Line::styled(
+                    notice,
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            );
+        }
+
+        if segment.truncated {
+            lines.push(Line::styled(
+                "… truncated; press → to load more",
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+
+        if let Some(token) = &segment.continuation {
+            lines.push(Line::styled(
+                format!("press enter to load from line {}", token.start_line + 1),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+
+        if lines.is_empty() {
+            lines.push(Line::styled(
+                "(empty file)",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
+        ratatui::widgets::Widget::render(paragraph, inner, buf);
+    }
+}
+
+fn highlight_span_to_span(span: &HighlightSpan) -> Span<'_> {
+    let mut style = Style::default();
+
+    if let Some(color) = span.style.foreground {
+        style = style.fg(Color::Rgb(color.r, color.g, color.b));
+    }
+    if let Some(color) = span.style.background {
+        style = style.bg(Color::Rgb(color.r, color.g, color.b));
+    }
+
+    if span.style.attributes.bold {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    if span.style.attributes.italic {
+        style = style.add_modifier(Modifier::ITALIC);
+    }
+    if span.style.attributes.underline {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+
+    Span::styled(span.content.clone(), style)
+}


### PR DESCRIPTION
## Summary
- add syntax highlighting infrastructure powered by syntect and embedded theme assets
- introduce application preview service with chunked loading, binary detection, and utf-8 fallback
- hook preview UI component to render highlighted segments with line numbers and notices

## Testing
- cargo test

Closes https://github.com/Jbolt01/llmctx/issues/5.
