### PR TITLE
Implement selection export pipeline and CLI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,23 @@ The token estimator supports the following model identifiers:
 
 Set `defaults.model` in the configuration or `LLMCTX_MODEL` in the environment to switch the active model. `defaults.token_budget` defines the maximum context window displayed in the TUI summary. When a precise tokenizer is unavailable, llmctx falls back to configurable character/word heuristics so estimates remain available offline.
 
+## Exporting Context
+
+Selections can be exported directly from the command line without launching the TUI. Use the `export` subcommand to specify files or ranges and control output:
+
+```sh
+# Export two files using the default Markdown template, writing to stdout and clipboard
+llmctx export src/lib.rs src/main.rs --copy --print
+
+# Export a line range with an inline note using the plain text template
+llmctx export \
+  --select "src/app/mod.rs:10-80#core wiring" \
+  --format plain \
+  --template plain_text \
+  --output context.txt
+```
+
+Selections accept the format `path[:start-end][#note]`. Ranges are inclusive and line-numbered output is enabled by default (configurable via `export.include_line_numbers`). The exporter respects configuration defaults for the target model, templates, and git metadata. Rendered output can be written to disk, copied to the clipboard, and/or printed to stdout in a single invocation.
+
 ## CI
 GitHub Actions workflow runs fmt, clippy, and tests on pushes and pull requests.

--- a/crates/llmctx/src/app/export.rs
+++ b/crates/llmctx/src/app/export.rs
@@ -1,10 +1,434 @@
 //! Export bundle handling.
 
-#[derive(Default)]
-pub struct Exporter;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Mutex;
 
-impl Exporter {
-    pub fn new() -> Self {
-        Self
+use anyhow::{Context, Result, anyhow};
+use clap::ValueEnum;
+use minijinja::Environment;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::app::tokens::BundleTokenSummary;
+use crate::domain::model::{ContextBundle, SelectionItem};
+use crate::infra::clipboard::Clipboard;
+use crate::infra::config::Config;
+use crate::infra::git::{self, GitMetadata};
+
+/// Supported export formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum ExportFormat {
+    /// Markdown document with fenced code blocks.
+    Markdown,
+    /// Plain text report.
+    Plain,
+}
+
+impl ExportFormat {
+    /// Return a stable identifier for templates and configuration.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ExportFormat::Markdown => "markdown",
+            ExportFormat::Plain => "plain",
+        }
+    }
+
+    /// Recommended file extension for the format.
+    pub fn extension(&self) -> &'static str {
+        match self {
+            ExportFormat::Markdown => "md",
+            ExportFormat::Plain => "txt",
+        }
     }
 }
+
+impl FromStr for ExportFormat {
+    type Err = ExportFormatParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "markdown" | "md" | "commonmark" => Ok(ExportFormat::Markdown),
+            "plain" | "text" | "txt" => Ok(ExportFormat::Plain),
+            other => Err(ExportFormatParseError::UnknownFormat(other.to_string())),
+        }
+    }
+}
+
+/// Error returned when parsing an [`ExportFormat`] fails.
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum ExportFormatParseError {
+    #[error("unknown export format '{0}'")]
+    UnknownFormat(String),
+}
+
+/// Runtime options controlling export behavior.
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    pub format: ExportFormat,
+    pub template: String,
+    pub include_line_numbers: bool,
+    pub include_git_metadata: bool,
+    pub output_path: Option<PathBuf>,
+    pub copy_to_clipboard: bool,
+}
+
+impl ExportOptions {
+    /// Build options from configuration defaults.
+    pub fn from_config(config: &Config) -> Self {
+        let format = <ExportFormat as std::str::FromStr>::from_str(config.defaults.export_format())
+            .unwrap_or(ExportFormat::Markdown);
+        Self {
+            format,
+            template: config.export.template(),
+            include_line_numbers: config.export.include_line_numbers(),
+            include_git_metadata: config.export.include_git_metadata(),
+            output_path: None,
+            copy_to_clipboard: false,
+        }
+    }
+}
+
+/// Result of an export operation.
+#[derive(Debug, Clone)]
+pub struct ExportResult {
+    pub rendered: String,
+    pub output_path: Option<PathBuf>,
+    pub copied_to_clipboard: bool,
+}
+
+/// Responsible for rendering bundles and writing artifacts.
+pub struct Exporter {
+    env: Environment<'static>,
+    clipboard: Mutex<Clipboard>,
+}
+
+impl Exporter {
+    /// Create a new exporter with built-in templates loaded.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            env: default_environment()?,
+            clipboard: Mutex::new(Clipboard::new()),
+        })
+    }
+
+    /// Render the provided bundle into a string using the supplied options.
+    pub fn render_bundle(
+        &self,
+        bundle: &ContextBundle,
+        summary: Option<&BundleTokenSummary>,
+        options: &ExportOptions,
+    ) -> Result<String> {
+        let git_metadata = if options.include_git_metadata {
+            bundle
+                .items
+                .first()
+                .and_then(|item| git::metadata_for_path(&item.path))
+        } else {
+            None
+        };
+
+        let context = build_template_context(bundle, summary, options, git_metadata)?;
+        self.render_with_template(&context, &options.template)
+    }
+
+    /// Render the bundle and persist/copy outputs based on options.
+    pub fn export(
+        &self,
+        bundle: &ContextBundle,
+        summary: Option<&BundleTokenSummary>,
+        options: &ExportOptions,
+    ) -> Result<ExportResult> {
+        let rendered = self.render_bundle(bundle, summary, options)?;
+
+        if let Some(path) = &options.output_path {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("failed to create export directory: {}", parent.display())
+                })?;
+            }
+            fs::write(path, &rendered)
+                .with_context(|| format!("failed to write export output to {}", path.display()))?;
+        }
+
+        if options.copy_to_clipboard {
+            self.clipboard
+                .lock()
+                .unwrap()
+                .copy(&rendered)
+                .context("failed to copy export to clipboard")?;
+        }
+
+        Ok(ExportResult {
+            rendered,
+            output_path: options.output_path.clone(),
+            copied_to_clipboard: options.copy_to_clipboard,
+        })
+    }
+
+    fn render_with_template(
+        &self,
+        context: &TemplateContext,
+        template_name: &str,
+    ) -> Result<String> {
+        if let Ok(template) = self.env.get_template(template_name) {
+            return template
+                .render(context)
+                .map_err(|err| anyhow!("failed to render template '{template_name}': {err}"));
+        }
+
+        let template_path = Path::new(template_name);
+        if template_path.exists() {
+            let source = fs::read_to_string(template_path).with_context(|| {
+                format!(
+                    "failed to load template from path {}",
+                    template_path.display()
+                )
+            })?;
+            let mut env = Environment::new();
+            env.set_trim_blocks(true);
+            env.set_lstrip_blocks(true);
+            env.add_template("external", &source)
+                .map_err(|err| anyhow!("invalid template '{}': {err}", template_name))?;
+            return env
+                .get_template("external")
+                .unwrap()
+                .render(context)
+                .map_err(|err| anyhow!("failed to render template '{template_name}': {err}"));
+        }
+
+        Err(anyhow!(
+            "template '{}' not found (built-in or filesystem)",
+            template_name
+        ))
+    }
+}
+
+fn default_environment() -> Result<Environment<'static>> {
+    let mut env = Environment::new();
+    env.set_trim_blocks(true);
+    env.set_lstrip_blocks(true);
+    env.add_template("concise_context", DEFAULT_MARKDOWN_TEMPLATE)
+        .map_err(|err| anyhow!("failed to register default markdown template: {err}"))?;
+    env.add_template("plain_text", DEFAULT_PLAIN_TEMPLATE)
+        .map_err(|err| anyhow!("failed to register default plain template: {err}"))?;
+    Ok(env)
+}
+
+fn build_template_context(
+    bundle: &ContextBundle,
+    summary: Option<&BundleTokenSummary>,
+    options: &ExportOptions,
+    git_metadata: Option<GitMetadata>,
+) -> Result<TemplateContext> {
+    let generated_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format export timestamp")?;
+
+    let mut selections = Vec::with_capacity(bundle.items.len());
+    for (index, item) in bundle.items.iter().enumerate() {
+        let summary_item = summary.and_then(|summary| summary.items.get(index));
+        let extracted = extract_selection_contents(item, options.include_line_numbers)?;
+        selections.push(TemplateSelection {
+            path: item.path.display().to_string(),
+            display_path: display_path(item, git_metadata.as_ref()),
+            range: item.range.map(|(start, end)| SelectionRange { start, end }),
+            start_line: extracted.start_line,
+            end_line: extracted.end_line,
+            contents: extracted.contents,
+            note: item.note.clone(),
+            tokens: summary_item.map(|entry| entry.tokens),
+            characters: summary_item
+                .map(|entry| entry.characters)
+                .or(Some(extracted.character_count)),
+        });
+    }
+
+    let tokens = summary.map(|summary| TemplateTokenSummary {
+        model: summary.model.as_str().to_string(),
+        token_budget: summary.token_budget,
+        total_tokens: summary.total_tokens,
+        total_characters: summary.total_characters,
+    });
+
+    Ok(TemplateContext {
+        generated_at,
+        format: options.format.as_str().to_string(),
+        model: bundle.model.clone(),
+        selections,
+        tokens,
+        git: git_metadata,
+    })
+}
+
+fn display_path(item: &SelectionItem, git_metadata: Option<&GitMetadata>) -> String {
+    let path = &item.path;
+    if let Some(metadata) = git_metadata
+        && let Ok(relative) = path.strip_prefix(&metadata.root)
+    {
+        return relative.display().to_string();
+    }
+
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(relative) = path.strip_prefix(&cwd)
+    {
+        return relative.display().to_string();
+    }
+
+    path.display().to_string()
+}
+
+fn extract_selection_contents(
+    item: &SelectionItem,
+    include_line_numbers: bool,
+) -> Result<SelectionExtraction> {
+    let contents = fs::read_to_string(&item.path).with_context(|| {
+        format!(
+            "failed to read selection contents from {}",
+            item.path.display()
+        )
+    })?;
+
+    let lines: Vec<&str> = contents.lines().collect();
+    let total_lines = lines.len();
+
+    let (raw_start, raw_end) = item.range.unwrap_or((1, total_lines.max(1)));
+    let start = raw_start.max(1);
+    let end = raw_end.max(start);
+    let available_end = if total_lines == 0 { 0 } else { total_lines };
+    let clamped_start = if available_end == 0 {
+        start
+    } else {
+        start.min(available_end)
+    };
+    let clamped_end = if available_end == 0 {
+        end
+    } else {
+        end.min(available_end)
+    };
+    let display_end = clamped_end.max(clamped_start);
+    let width = display_end.max(1).to_string().len();
+
+    let mut extracted_lines = Vec::new();
+    for (idx, line) in contents.lines().enumerate() {
+        let line_no = idx + 1;
+        if line_no < clamped_start || line_no > clamped_end {
+            continue;
+        }
+        if include_line_numbers {
+            extracted_lines.push(format!("{line_no:>width$} │ {line}", width = width));
+        } else {
+            extracted_lines.push(line.to_string());
+        }
+    }
+
+    let joined = extracted_lines.join("\n");
+    Ok(SelectionExtraction {
+        contents: joined.clone(),
+        start_line: Some(clamped_start),
+        end_line: Some(clamped_end),
+        character_count: joined.chars().count(),
+    })
+}
+
+#[derive(Serialize)]
+struct TemplateContext {
+    generated_at: String,
+    format: String,
+    model: Option<String>,
+    selections: Vec<TemplateSelection>,
+    tokens: Option<TemplateTokenSummary>,
+    git: Option<GitMetadata>,
+}
+
+#[derive(Serialize)]
+struct TemplateSelection {
+    path: String,
+    display_path: String,
+    range: Option<SelectionRange>,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+    contents: String,
+    note: Option<String>,
+    tokens: Option<usize>,
+    characters: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct SelectionRange {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Serialize)]
+struct TemplateTokenSummary {
+    model: String,
+    token_budget: u32,
+    total_tokens: usize,
+    total_characters: usize,
+}
+
+struct SelectionExtraction {
+    contents: String,
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+    character_count: usize,
+}
+
+const DEFAULT_MARKDOWN_TEMPLATE: &str = r#"# Curated Context
+
+Generated at: {{ generated_at }}
+
+{% if tokens %}
+## Token Summary
+- Model: {{ tokens.model }}
+- Usage: {{ tokens.total_tokens }} / {{ tokens.token_budget }} tokens
+- Characters: {{ tokens.total_characters }}
+{% endif %}
+
+{% if git %}
+## Repository
+- Root: {{ git.root }}
+{% if git.branch %}- Branch: {{ git.branch }}{% endif %}
+{% if git.commit %}- Commit: {{ git.commit }}{% endif %}
+{% endif %}
+
+{% for selection in selections %}
+## {{ loop.index }}. {{ selection.display_path }}
+{% if selection.range %}_Lines {{ selection.range.start }}-{{ selection.range.end }}_{% endif %}
+{% if selection.note %}> {{ selection.note }}
+
+{% endif %}
+```text
+{{ selection.contents }}
+```
+
+{% if selection.tokens %}- Tokens: {{ selection.tokens }}{% endif %}
+{% if selection.characters %}- Characters: {{ selection.characters }}{% endif %}
+
+{% endfor %}
+"#;
+
+const DEFAULT_PLAIN_TEMPLATE: &str = r#"Curated context generated at {{ generated_at }}
+
+{% if tokens %}Token summary: model {{ tokens.model }}, {{ tokens.total_tokens }}/{{ tokens.token_budget }} tokens, {{ tokens.total_characters }} characters.
+{% endif %}
+{% if git %}Repository: {{ git.root }}{% if git.branch %} (branch {{ git.branch }}){% endif %}{% if git.commit %} commit {{ git.commit }}{% endif %}.
+{% endif %}
+
+{% for selection in selections %}
+-- {{ loop.index }}. {{ selection.display_path }}{% if selection.range %} (lines {{ selection.range.start }}-{{ selection.range.end }}){% endif %}
+{% if selection.note %}Note: {{ selection.note }}
+{% endif %}
+{{ selection.contents }}
+
+{% if selection.tokens %}Tokens: {{ selection.tokens }}{% endif %}{% if selection.characters %} Characters: {{ selection.characters }}{% endif %}
+
+{% endfor %}
+"#;

--- a/crates/llmctx/src/app/export.rs
+++ b/crates/llmctx/src/app/export.rs
@@ -301,7 +301,16 @@ fn extract_selection_contents(
     let (raw_start, raw_end) = item.range.unwrap_or((1, total_lines.max(1)));
     let start = raw_start.max(1);
     let end = raw_end.max(start);
-    let available_end = if total_lines == 0 { 0 } else { total_lines };
+    if total_lines == 0 || start > total_lines {
+        return Ok(SelectionExtraction {
+            contents: String::new(),
+            start_line: None,
+            end_line: None,
+            character_count: 0,
+        });
+    }
+
+    let available_end = total_lines;
     let clamped_start = if available_end == 0 {
         start
     } else {

--- a/crates/llmctx/src/app/selection.rs
+++ b/crates/llmctx/src/app/selection.rs
@@ -1,10 +1,333 @@
 //! Managing selections and context bundles.
 
-#[derive(Default)]
-pub struct SelectionManager;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::app::tokens::{BundleTokenSummary, TokenEstimator};
+use crate::domain::model::{ContextBundle, SelectionItem};
+
+/// Tracks the active selection set and produces export-ready bundles.
+#[derive(Debug, Default, Clone)]
+pub struct SelectionManager {
+    items: Vec<SelectionItem>,
+    model: Option<String>,
+}
 
 impl SelectionManager {
+    /// Create an empty manager.
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Returns the number of tracked selections.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns whether any selections exist.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Replace the associated model for bundle generation.
+    pub fn set_model<S: Into<String>>(&mut self, model: S) {
+        self.model = Some(model.into());
+    }
+
+    /// Clear the configured model, falling back to estimator defaults.
+    pub fn clear_model(&mut self) {
+        self.model = None;
+    }
+
+    /// Access the active selections.
+    pub fn items(&self) -> &[SelectionItem] {
+        &self.items
+    }
+
+    /// Append or merge a selection.
+    ///
+    /// Entire file selections replace any previous ranges for the same path. Ranged selections are
+    /// merged when they overlap or touch to keep the bundle compact while preserving insertion
+    /// order.
+    pub fn add_selection(
+        &mut self,
+        path: impl Into<PathBuf>,
+        range: Option<(usize, usize)>,
+        note: Option<String>,
+    ) -> SelectionItem {
+        let item = SelectionItem {
+            path: path.into(),
+            range: range.map(normalize_range),
+            note: note.and_then(clean_note),
+        };
+
+        match item.range {
+            None => self.insert_entire_file(item),
+            Some(range) => self.insert_range(item, range),
+        }
+    }
+
+    /// Remove a specific selection. When `range` is `None`, all selections for the file are
+    /// cleared.
+    pub fn remove_selection(&mut self, path: &Path, range: Option<(usize, usize)>) -> bool {
+        let original_len = self.items.len();
+        match range.map(normalize_range) {
+            None => self.items.retain(|item| item.path != path),
+            Some(target) => self.items.retain(|item| {
+                if item.path != path {
+                    return true;
+                }
+                item.range != Some(target)
+            }),
+        }
+        self.items.len() != original_len
+    }
+
+    /// Update the note associated with a selection. Returns `true` when a matching selection is
+    /// found.
+    pub fn set_note(
+        &mut self,
+        path: &Path,
+        range: Option<(usize, usize)>,
+        note: Option<String>,
+    ) -> bool {
+        let normalized = range.map(normalize_range);
+        let note = note.and_then(clean_note);
+
+        if let Some(item) = self.items.iter_mut().find(|item| {
+            item.path == path
+                && match (item.range, normalized) {
+                    (None, None) => true,
+                    (Some(existing), Some(target)) => existing == target,
+                    _ => false,
+                }
+        }) {
+            item.note = note;
+            return true;
+        }
+
+        false
+    }
+
+    /// Remove all selections.
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.model = None;
+    }
+
+    /// Build a [`ContextBundle`] from the tracked selections, using an optional override model.
+    pub fn to_bundle_with_model(&self, override_model: Option<String>) -> ContextBundle {
+        ContextBundle {
+            items: self.items.clone(),
+            model: override_model.or_else(|| self.model.clone()),
+        }
+    }
+
+    /// Build a [`ContextBundle`] using the internally configured model (if any).
+    pub fn to_bundle(&self) -> ContextBundle {
+        self.to_bundle_with_model(None)
+    }
+
+    /// Estimate tokens for the active bundle using the provided estimator.
+    pub fn summarize_tokens(
+        &self,
+        estimator: &TokenEstimator,
+    ) -> Result<Option<BundleTokenSummary>> {
+        if self.items.is_empty() {
+            return Ok(None);
+        }
+        let bundle = self.to_bundle();
+        estimator.estimate_bundle(&bundle).map(Some)
+    }
+
+    fn insert_entire_file(&mut self, mut item: SelectionItem) -> SelectionItem {
+        let mut insert_at = None;
+        let mut preserved_note = item.note.clone();
+
+        let mut index = 0;
+        while index < self.items.len() {
+            if self.items[index].path == item.path {
+                if insert_at.is_none() {
+                    insert_at = Some(index);
+                }
+                if preserved_note.is_none() {
+                    preserved_note = self.items[index].note.clone();
+                }
+                self.items.remove(index);
+            } else {
+                index += 1;
+            }
+        }
+
+        if item.note.is_none() {
+            item.note = preserved_note;
+        }
+
+        let position = insert_at.unwrap_or(self.items.len());
+        self.items.insert(position, item.clone());
+        item
+    }
+
+    fn insert_range(
+        &mut self,
+        mut item: SelectionItem,
+        mut range: (usize, usize),
+    ) -> SelectionItem {
+        let mut merged_indices: Vec<usize> = Vec::new();
+        let mut inherited_note = item.note.clone();
+
+        for (idx, existing) in self.items.iter().enumerate() {
+            if existing.path != item.path {
+                continue;
+            }
+
+            match existing.range {
+                None => {
+                    let mut updated = existing.clone();
+                    if item.note.is_some() {
+                        updated.note = item.note.clone();
+                        self.items[idx] = updated.clone();
+                    }
+                    return updated;
+                }
+                Some(existing_range) => {
+                    if ranges_mergeable(range, existing_range) {
+                        merged_indices.push(idx);
+                        range = (range.0.min(existing_range.0), range.1.max(existing_range.1));
+                        if inherited_note.is_none() {
+                            inherited_note = existing.note.clone();
+                        }
+                    }
+                }
+            }
+        }
+
+        if !merged_indices.is_empty() {
+            for idx in merged_indices.iter().rev() {
+                self.items.remove(*idx);
+            }
+        }
+
+        item.range = Some(range);
+        if item.note.is_none() {
+            item.note = inherited_note;
+        }
+
+        let position = self
+            .items
+            .iter()
+            .enumerate()
+            .find(|(_, existing)| {
+                existing.path == item.path
+                    && existing
+                        .range
+                        .map(|existing_range| existing_range.0 > range.1)
+                        .unwrap_or(false)
+            })
+            .map(|(idx, _)| idx)
+            .unwrap_or_else(|| {
+                self.items
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .find(|(_, existing)| existing.path == item.path)
+                    .map(|(idx, _)| idx + 1)
+                    .unwrap_or(self.items.len())
+            });
+
+        self.items.insert(position, item.clone());
+        item
+    }
+}
+
+fn normalize_range(range: (usize, usize)) -> (usize, usize) {
+    let start = range.0.min(range.1).max(1);
+    let end = range.0.max(range.1).max(1);
+    (start, end)
+}
+
+fn ranges_mergeable(a: (usize, usize), b: (usize, usize)) -> bool {
+    let (a_start, a_end) = a;
+    let (b_start, b_end) = b;
+    a_start <= b_end.saturating_add(1) && b_start <= a_end.saturating_add(1)
+}
+
+fn clean_note(note: String) -> Option<String> {
+    let trimmed = note.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn adds_entire_file_and_replaces_existing_ranges() {
+        let mut manager = SelectionManager::new();
+        let path: PathBuf = "src/lib.rs".into();
+
+        manager.add_selection(path.clone(), Some((5, 10)), None);
+        manager.add_selection(path.clone(), Some((15, 20)), Some("note".into()));
+        assert_eq!(manager.len(), 2);
+
+        manager.add_selection(path.clone(), None, None);
+        assert_eq!(manager.len(), 1);
+        assert_eq!(manager.items()[0].range, None);
+        assert_eq!(manager.items()[0].note, Some("note".into()));
+    }
+
+    #[test]
+    fn merges_overlapping_ranges_and_preserves_order() {
+        let mut manager = SelectionManager::new();
+        let path: PathBuf = "src/lib.rs".into();
+
+        let first = manager.add_selection(path.clone(), Some((5, 10)), None);
+        assert_eq!(first.range, Some((5, 10)));
+
+        let merged = manager.add_selection(path.clone(), Some((9, 15)), None);
+        assert_eq!(merged.range, Some((5, 15)));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn set_note_updates_existing_selection() {
+        let mut manager = SelectionManager::new();
+        let path: PathBuf = "src/lib.rs".into();
+        manager.add_selection(path.clone(), Some((1, 3)), None);
+
+        assert!(manager.set_note(&path, Some((1, 3)), Some("important".into())));
+        assert_eq!(manager.items()[0].note.as_deref(), Some("important"));
+    }
+
+    #[test]
+    fn summarize_tokens_returns_none_when_empty() {
+        let manager = SelectionManager::new();
+        let estimator = TokenEstimator::new(Default::default());
+        assert!(manager.summarize_tokens(&estimator).unwrap().is_none());
+    }
+
+    #[test]
+    fn summarize_tokens_reads_ranges() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "line one").unwrap();
+        writeln!(file, "line two").unwrap();
+        writeln!(file, "line three").unwrap();
+
+        let mut manager = SelectionManager::new();
+        manager.add_selection(file.path(), Some((2, 3)), None);
+
+        let estimator = TokenEstimator::new(Default::default());
+        let summary = manager.summarize_tokens(&estimator).unwrap().unwrap();
+        assert_eq!(summary.items.len(), 1);
+        assert!(summary.total_tokens > 0);
     }
 }

--- a/crates/llmctx/src/infra/clipboard.rs
+++ b/crates/llmctx/src/infra/clipboard.rs
@@ -1,10 +1,97 @@
 //! Clipboard integration utilities.
 
-#[derive(Default)]
-pub struct Clipboard;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow};
+
+/// Cross-platform clipboard helper with fallbacks for headless environments.
+pub struct Clipboard {
+    primary: Option<arboard::Clipboard>,
+}
 
 impl Clipboard {
+    /// Attempt to initialize the system clipboard. When unavailable we fall back to shell-based
+    /// clipboard utilities.
     pub fn new() -> Self {
-        Self
+        let primary = arboard::Clipboard::new().ok();
+        Self { primary }
     }
+
+    /// Copy text to the clipboard, falling back to platform-specific executables if needed.
+    pub fn copy(&mut self, text: &str) -> Result<()> {
+        if let Some(primary) = self.primary.as_mut()
+            && primary.set_text(text.to_owned()).is_ok()
+        {
+            return Ok(());
+        }
+
+        self.primary = None;
+        fallback_copy(text)
+    }
+}
+
+impl Default for Clipboard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn fallback_copy(text: &str) -> Result<()> {
+    for command in fallback_commands() {
+        if try_command_copy(command, text).is_ok() {
+            return Ok(());
+        }
+    }
+
+    Err(anyhow!(
+        "failed to copy text to clipboard using available backends"
+    ))
+}
+
+fn try_command_copy(command: &[&str], text: &str) -> Result<()> {
+    let (program, args) = command
+        .split_first()
+        .context("clipboard command missing program")?;
+
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to spawn clipboard command: {program}"))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin
+            .write_all(text.as_bytes())
+            .context("failed to write clipboard contents")?;
+    }
+
+    let status = child
+        .wait()
+        .with_context(|| format!("clipboard command did not exit cleanly: {program}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("clipboard command exited with status {status}"))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn fallback_commands() -> Vec<&'static [&'static str]> {
+    vec![&["pbcopy"]]
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn fallback_commands() -> Vec<&'static [&'static str]> {
+    vec![&["xclip", "-selection", "clipboard"], &["wl-copy"]]
+}
+
+#[cfg(target_os = "windows")]
+fn fallback_commands() -> Vec<&'static [&'static str]> {
+    vec![&["powershell.exe", "-NoProfile", "-Command", "Set-Clipboard"]]
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+fn fallback_commands() -> Vec<&'static [&'static str]> {
+    Vec::new()
 }

--- a/crates/llmctx/src/infra/config.rs
+++ b/crates/llmctx/src/infra/config.rs
@@ -251,6 +251,18 @@ impl Config {
         Self::load_with_layers(global, workspace, env)
     }
 
+    /// Load configuration from a single explicit path layered on top of defaults.
+    pub fn load_from_path(path: &Path) -> Result<Self> {
+        let defaults = Self::from_str(&DEFAULT_CONFIG)?;
+        let explicit = Self::from_file(path)?;
+        Ok(defaults.merge(explicit))
+    }
+
+    /// Merge another configuration on top of this instance, returning the combined result.
+    pub fn merge_with(self, other: Config) -> Config {
+        self.merge(other)
+    }
+
     fn load_with_layers(
         global: Option<PathBuf>,
         workspace: Option<PathBuf>,

--- a/crates/llmctx/src/infra/git.rs
+++ b/crates/llmctx/src/infra/git.rs
@@ -1,10 +1,54 @@
 //! Git integration utilities.
 
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Lightweight wrapper around [`gix::Repository`] discovery for metadata extraction.
 #[derive(Default)]
-pub struct GitClient;
+pub struct GitClient {
+    repo: Option<gix::Repository>,
+}
 
 impl GitClient {
-    pub fn new() -> Self {
-        Self
+    /// Attempt to locate a git repository starting from `path`.
+    pub fn discover(path: impl AsRef<Path>) -> Result<Self> {
+        let repo = gix::discover(path).ok();
+        Ok(Self { repo })
     }
+
+    /// Retrieve repository metadata if discovery succeeded.
+    pub fn metadata(&self) -> Option<GitMetadata> {
+        let repo = self.repo.as_ref()?;
+        let branch = repo.head_name().ok().flatten().map(|name| name.to_string());
+
+        let commit = repo.head_id().ok().map(|id| id.detach().to_string());
+
+        let root = repo
+            .work_dir()
+            .map(Path::to_path_buf)
+            .or_else(|| repo.path().parent().map(Path::to_path_buf))?;
+
+        Some(GitMetadata {
+            branch,
+            commit,
+            root,
+        })
+    }
+}
+
+/// Basic information about the repository used in export templates.
+#[derive(Debug, Clone, Serialize)]
+pub struct GitMetadata {
+    pub branch: Option<String>,
+    pub commit: Option<String>,
+    pub root: PathBuf,
+}
+
+/// Convenience helper to retrieve metadata directly from a path.
+pub fn metadata_for_path(path: &Path) -> Option<GitMetadata> {
+    GitClient::discover(path)
+        .ok()
+        .and_then(|client| client.metadata())
 }

--- a/crates/llmctx/src/main.rs
+++ b/crates/llmctx/src/main.rs
@@ -1,6 +1,194 @@
-fn main() -> anyhow::Result<()> {
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use clap::{Args as ClapArgs, Parser, Subcommand, ValueHint};
+
+use llmctx::app::export::{ExportFormat, ExportOptions, Exporter};
+use llmctx::app::selection::SelectionManager;
+use llmctx::app::tokens::TokenEstimator;
+use llmctx::infra::config::Config;
+
+fn main() -> Result<()> {
     llmctx::init();
 
+    let cli = Cli::parse();
+    match cli.command.unwrap_or_default() {
+        Command::Export(args) => run_export(args),
+        Command::Tui => run_tui(),
+    }
+}
+
+fn run_tui() -> Result<()> {
     let mut app = llmctx::ui::app::UiApp;
     app.run()
+}
+
+fn run_export(args: ExportArgs) -> Result<()> {
+    let mut config = Config::load()?;
+    if let Some(path) = &args.config {
+        let overlay = Config::load_from_path(path)
+            .with_context(|| format!("failed to load configuration from {}", path.display()))?;
+        config = config.merge_with(overlay);
+    }
+
+    let selections = build_selection_manager(&args)?;
+    if selections.is_empty() {
+        return Err(anyhow!("at least one selection must be provided"));
+    }
+
+    let mut manager = SelectionManager::new();
+    let model = args
+        .model
+        .unwrap_or_else(|| config.defaults.model().to_string());
+    manager.set_model(model);
+    for selection in selections {
+        manager.add_selection(selection.path, selection.range, selection.note);
+    }
+
+    let estimator = TokenEstimator::from_config(&config);
+    let summary = manager.summarize_tokens(&estimator)?;
+
+    let mut options = ExportOptions::from_config(&config);
+    if let Some(format) = args.format {
+        options.format = format;
+    }
+    if let Some(template) = args.template {
+        options.template = template;
+    }
+    options.output_path = args.output.clone();
+    options.copy_to_clipboard = args.copy;
+
+    let exporter = Exporter::new()?;
+    let bundle = manager.to_bundle();
+    let result = exporter.export(&bundle, summary.as_ref(), &options)?;
+
+    if args.print {
+        println!("{}", result.rendered);
+    }
+
+    Ok(())
+}
+
+fn build_selection_manager(args: &ExportArgs) -> Result<Vec<SelectionSpec>> {
+    let mut selections = Vec::new();
+
+    for spec in &args.selections {
+        selections.push(spec.clone());
+    }
+
+    for path in &args.paths {
+        selections.push(SelectionSpec {
+            path: path.clone(),
+            range: None,
+            note: None,
+        });
+    }
+
+    Ok(selections)
+}
+
+#[derive(Parser)]
+#[command(
+    name = "llmctx",
+    version,
+    about = "Curate and export context for LLM prompts"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Default)]
+enum Command {
+    /// Launch the interactive terminal UI.
+    #[default]
+    Tui,
+    /// Export selections without launching the UI.
+    Export(ExportArgs),
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+struct ExportArgs {
+    /// Additional configuration file layered on top of defaults.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    config: Option<PathBuf>,
+    /// Override the export format (markdown/plain).
+    #[arg(long)]
+    format: Option<ExportFormat>,
+    /// Override the template name or path.
+    #[arg(long)]
+    template: Option<String>,
+    /// Path to write the export contents to.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    output: Option<PathBuf>,
+    /// Copy the rendered export to the system clipboard.
+    #[arg(long)]
+    copy: bool,
+    /// Print the rendered output to stdout in addition to other actions.
+    #[arg(long)]
+    print: bool,
+    /// Override the token model used for estimation.
+    #[arg(long)]
+    model: Option<String>,
+    /// Explicit selections with optional ranges and notes (path[:start-end][#note]).
+    #[arg(long = "select", value_name = "SPEC", value_parser = parse_selection_spec)]
+    selections: Vec<SelectionSpec>,
+    /// Entire file selections provided as positional arguments.
+    #[arg(value_name = "PATH", value_hint = ValueHint::FilePath)]
+    paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+struct SelectionSpec {
+    path: PathBuf,
+    range: Option<(usize, usize)>,
+    note: Option<String>,
+}
+
+fn parse_selection_spec(value: &str) -> Result<SelectionSpec, String> {
+    let (target, note) = match value.split_once('#') {
+        Some((target, note)) => (target.trim(), clean_note_string(note)),
+        None => (value.trim(), None),
+    };
+
+    if target.is_empty() {
+        return Err("selection specification is empty".to_string());
+    }
+
+    let mut path_part = target;
+    let mut range = None;
+
+    if let Some(colon_idx) = target.rfind(':') {
+        let (candidate_path, candidate_range) = target.split_at(colon_idx);
+        if let Some(parsed_range) = parse_range(&candidate_range[1..]) {
+            path_part = candidate_path;
+            range = Some(parsed_range);
+        }
+    }
+
+    if path_part.is_empty() {
+        return Err("selection path is empty".to_string());
+    }
+
+    Ok(SelectionSpec {
+        path: PathBuf::from(path_part),
+        range,
+        note,
+    })
+}
+
+fn parse_range(spec: &str) -> Option<(usize, usize)> {
+    let (start, end) = spec.split_once('-')?;
+    let start = start.trim().parse::<usize>().ok()?;
+    let end = end.trim().parse::<usize>().ok()?;
+    Some((start, end))
+}
+
+fn clean_note_string(note: &str) -> Option<String> {
+    let trimmed = note.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use llmctx::app::export::{ExportFormat, ExportOptions, Exporter};
+use llmctx::app::selection::SelectionManager;
+use llmctx::app::tokens::TokenEstimator;
+use llmctx::infra::config::Config;
+use tempfile::NamedTempFile;
+
+fn create_temp_file(contents: &str) -> (PathBuf, NamedTempFile) {
+    let mut file = NamedTempFile::new().expect("temp file");
+    write!(file, "{}", contents).expect("write contents");
+    (file.path().to_path_buf(), file)
+}
+
+#[test]
+fn exports_markdown_bundle_with_line_numbers() {
+    let (path, _file) = create_temp_file("fn main() {}\n// comment\nprintln!(\"done\");\n");
+
+    let mut manager = SelectionManager::new();
+    manager.add_selection(&path, Some((1, 2)), Some("core entry point".into()));
+
+    let config = Config::default();
+    let estimator = TokenEstimator::from_config(&config);
+    let summary = manager.summarize_tokens(&estimator).unwrap();
+
+    let mut options = ExportOptions::from_config(&config);
+    let temp_dir = tempfile::tempdir().unwrap();
+    let output_path = temp_dir.path().join("context.md");
+    options.output_path = Some(output_path.clone());
+
+    let exporter = Exporter::new().unwrap();
+    let bundle = manager.to_bundle();
+    let result = exporter.export(&bundle, summary.as_ref(), &options).unwrap();
+
+    assert!(result.rendered.contains("Curated Context"));
+    assert!(result.rendered.contains("Lines 1-2"));
+    assert!(result.rendered.contains("fn main() {}"));
+    assert!(result.rendered.contains("core entry point"));
+
+    let written = fs::read_to_string(output_path).unwrap();
+    assert!(written.contains("Curated Context"));
+}
+
+#[test]
+fn exports_plain_text_when_requested() {
+    let (path, _file) = create_temp_file("alpha\nbeta\n");
+
+    let mut manager = SelectionManager::new();
+    manager.add_selection(&path, None, None);
+
+    let config = Config::default();
+    let estimator = TokenEstimator::from_config(&config);
+    let summary = manager.summarize_tokens(&estimator).unwrap();
+
+    let mut options = ExportOptions::from_config(&config);
+    options.format = ExportFormat::Plain;
+    options.template = "plain_text".into();
+
+    let exporter = Exporter::new().unwrap();
+    let bundle = manager.to_bundle();
+    let result = exporter.export(&bundle, summary.as_ref(), &options).unwrap();
+
+    assert!(result.rendered.contains("Curated context generated"));
+    assert!(result.rendered.contains("alpha"));
+    assert!(result.rendered.contains("beta"));
+}


### PR DESCRIPTION
## Summary
- implement a fully featured `SelectionManager` capable of merging ranges, handling notes, and producing token summaries for bundles
- add a templated exporter with Markdown/plain text outputs, clipboard fallbacks, git metadata, and integration tests for exported content
- introduce the `llmctx export` CLI, supporting selection specs, config overrides, and updated README guidance

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

Closes https://github.com/Jbolt01/llmctx/issues/7.

------
https://chatgpt.com/codex/tasks/task_e_68d38b16d3a883228e979123cc91a2c2