### PR TITLE
feat: launch interactive TUI MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,41 @@ llmctx is a Rust-based terminal UI for assembling curated code context for large
 cargo run -p llmctx
 ```
 
+### Interactive TUI
+
+Launching `cargo run -p llmctx` opens a full-screen terminal experience composed of:
+
+- **Workspace tree** (left) – browse the repository, expand/collapse folders, and toggle selections.
+- **Preview** (center) – syntax-highlighted file view with incremental loading for large files.
+- **Selection summary** (right) – live token estimates and export readiness.
+- **Command hints & status** (bottom) – discoverable shortcuts and contextual feedback.
+
+#### Core keybindings
+
+| Keys | Action |
+| --- | --- |
+| `j` / `↓` &nbsp;&nbsp;`k` / `↑` | Move through the file tree |
+| `h` / `←` | Collapse directory or jump to parent |
+| `l` / `→` / `Enter` | Expand directory or open preview |
+| `Tab` | Switch between tree and preview panes |
+| `Space` | Toggle whole-file selection |
+| `Shift` + `↑` / `↓` | Grow or shrink a line range selection in the preview |
+| `/` | Start incremental filter on the file tree |
+| `:` | Open the command palette |
+| `Ctrl+S` | Persist the current session to `.llmctx/session.json` |
+| `Ctrl+E` | Export the active selection bundle (writes to `.llmctx/exports/` and copies to clipboard) |
+| `q` / `Ctrl+Q` | Quit |
+
+The command palette supports quick actions such as:
+
+- `filter <pattern>` – apply a name filter to the file tree
+- `select <start-end>` – add a specific line range for the active preview
+- `export [path]` – write the current bundle to an explicit path
+- `save` – persist selections and UI state
+- `model <id>` – switch the active token model
+
+Session state (tree filter, focused file, selections, and model override) is automatically reloaded on startup when `.llmctx/session.json` is present.
+
 ## Project Structure
 - `Cargo.toml`: Workspace manifest.
 - `crates/llmctx`: Main binary crate.

--- a/crates/llmctx/src/app/selection.rs
+++ b/crates/llmctx/src/app/selection.rs
@@ -40,6 +40,11 @@ impl SelectionManager {
         self.model = None;
     }
 
+    /// Access the configured model if set.
+    pub fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
     /// Access the active selections.
     pub fn items(&self) -> &[SelectionItem] {
         &self.items

--- a/crates/llmctx/src/app/session.rs
+++ b/crates/llmctx/src/app/session.rs
@@ -1,10 +1,101 @@
 //! Session persistence utilities.
 
-#[derive(Default)]
-pub struct SessionStore;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::model::SelectionItem;
+
+const SESSION_DIR: &str = ".llmctx";
+const SESSION_FILE: &str = "session.json";
+
+/// Snapshot of interactive UI state persisted between sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SessionSnapshot {
+    /// Previously selected items restored into the selection manager.
+    pub selections: Vec<SelectionRecord>,
+    /// Path of the file that was focused when the session closed.
+    pub focused_path: Option<String>,
+    /// Active file tree filter.
+    pub filter: Option<String>,
+    /// User configured model override if any.
+    pub model: Option<String>,
+}
+
+/// Serializable representation of a [`SelectionItem`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SelectionRecord {
+    pub path: String,
+    pub range: Option<(usize, usize)>,
+    pub note: Option<String>,
+}
+
+impl From<&SelectionItem> for SelectionRecord {
+    fn from(value: &SelectionItem) -> Self {
+        Self {
+            path: value.path.display().to_string(),
+            range: value.range,
+            note: value.note.clone(),
+        }
+    }
+}
+
+impl SelectionRecord {
+    /// Convert the record back into a domain [`SelectionItem`].
+    pub fn into_selection_item(self) -> SelectionItem {
+        SelectionItem {
+            path: PathBuf::from(self.path),
+            range: self.range,
+            note: self.note,
+        }
+    }
+}
+
+/// Persists UI state to a session file under `.llmctx/`.
+#[derive(Debug, Clone)]
+pub struct SessionStore {
+    root: PathBuf,
+    path: PathBuf,
+}
 
 impl SessionStore {
-    pub fn new() -> Self {
-        Self
+    /// Create a new store rooted at the provided directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        let path = root.join(SESSION_DIR).join(SESSION_FILE);
+        Self { root, path }
+    }
+
+    /// Location of the persisted session file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Load the most recently persisted session snapshot.
+    pub fn load(&self) -> Result<Option<SessionSnapshot>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+
+        let data = fs::read_to_string(&self.path)
+            .with_context(|| format!("failed to read session file at {}", self.path.display()))?;
+        let snapshot = serde_json::from_str(&data)
+            .with_context(|| format!("invalid session data in {}", self.path.display()))?;
+        Ok(Some(snapshot))
+    }
+
+    /// Persist the provided snapshot to disk, creating parent directories as needed.
+    pub fn save(&self, snapshot: &SessionSnapshot) -> Result<()> {
+        let dir = self.path.parent().unwrap_or(&self.root);
+        fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create session directory {}", dir.display()))?;
+
+        let data = serde_json::to_string_pretty(snapshot)
+            .context("failed to serialize session snapshot")?;
+        fs::write(&self.path, data)
+            .with_context(|| format!("failed to write session file to {}", self.path.display()))?;
+        Ok(())
     }
 }

--- a/crates/llmctx/src/main.rs
+++ b/crates/llmctx/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
 }
 
 fn run_tui() -> Result<()> {
-    let mut app = llmctx::ui::app::UiApp;
+    let mut app = llmctx::ui::app::UiApp::default();
     app.run()
 }
 

--- a/crates/llmctx/src/ui/app.rs
+++ b/crates/llmctx/src/ui/app.rs
@@ -1,11 +1,984 @@
 //! Application loop for the TUI.
 
-#[derive(Default)]
-pub struct UiApp;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::{Frame, Terminal};
+use time::OffsetDateTime;
+use time::macros::format_description;
+
+use crate::app::export::{ExportOptions, Exporter};
+use crate::app::preview::{PreviewSegment, PreviewService};
+use crate::app::scan::{ScanResult, Scanner, ScannerConfig};
+use crate::app::selection::SelectionManager;
+use crate::app::session::{SelectionRecord, SessionSnapshot, SessionStore};
+use crate::app::tokens::{BundleTokenSummary, TokenEstimator};
+use crate::infra::config::Config;
+use crate::ui::components::command_palette::{CommandPalette, CommandPaletteState};
+use crate::ui::components::file_tree::{FileTree, FileTreeState};
+use crate::ui::components::preview::Preview;
+use crate::ui::components::summary::Summary;
+
+const TICK_RATE: Duration = Duration::from_millis(120);
+
+/// Primary entry point for running the interactive TUI.
+pub struct UiApp {
+    config: Config,
+    scanner: Scanner,
+    scan: Option<ScanResult>,
+    tree: FileTreeState,
+    file_tree: FileTree,
+    preview_service: PreviewService,
+    preview: PreviewState,
+    selection: SelectionManager,
+    token_estimator: TokenEstimator,
+    summary_component: Summary,
+    last_summary: Option<BundleTokenSummary>,
+    session_store: SessionStore,
+    palette_state: CommandPaletteState,
+    palette_component: CommandPalette,
+    exporter: Exporter,
+    selected_paths: HashSet<String>,
+    path_lookup: HashMap<PathBuf, String>,
+    status: Option<StatusMessage>,
+    focus: FocusTarget,
+    should_quit: bool,
+}
+
+impl Default for UiApp {
+    fn default() -> Self {
+        Self {
+            config: Config::default(),
+            scanner: Scanner::new(),
+            scan: None,
+            tree: FileTreeState::default(),
+            file_tree: FileTree,
+            preview_service: PreviewService::new(),
+            preview: PreviewState::default(),
+            selection: SelectionManager::new(),
+            token_estimator: TokenEstimator::default(),
+            summary_component: Summary::new(),
+            last_summary: None,
+            session_store: SessionStore::new(PathBuf::from(".")),
+            palette_state: CommandPaletteState::default(),
+            palette_component: CommandPalette,
+            exporter: Exporter::new().expect("exporter available"),
+            selected_paths: HashSet::new(),
+            path_lookup: HashMap::new(),
+            status: None,
+            focus: FocusTarget::FileTree,
+            should_quit: false,
+        }
+    }
+}
 
 impl UiApp {
-    pub fn run(&mut self) -> anyhow::Result<()> {
-        // TODO: implement TUI loop
+    /// Launch the terminal UI and enter the event loop.
+    pub fn run(&mut self) -> Result<()> {
+        self.bootstrap()?;
+
+        enable_raw_mode().context("failed to enable raw mode")?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen).context("failed to enter alternate screen")?;
+
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend).context("failed to initialize terminal")?;
+        terminal.hide_cursor().ok();
+
+        let event_loop_result = self.event_loop(&mut terminal);
+
+        disable_raw_mode().ok();
+        let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+        let _ = terminal.show_cursor();
+
+        event_loop_result
+    }
+
+    fn bootstrap(&mut self) -> Result<()> {
+        self.config = Config::load()?;
+        let root = std::env::current_dir().context("unable to determine working directory")?;
+        self.session_store = SessionStore::new(&root);
+
+        let mut scanner_cfg = ScannerConfig::from_root(root.clone(), self.config.clone());
+        scanner_cfg = scanner_cfg.with_max_file_size(2 * 1024 * 1024);
+        let scan = self
+            .scanner
+            .scan(&scanner_cfg)
+            .context("failed to scan workspace")?;
+        self.path_lookup = scan
+            .files
+            .iter()
+            .map(|meta| (meta.path.clone(), meta.display_path.clone()))
+            .collect();
+        self.tree = FileTreeState::from_scan(&scan);
+        self.scan = Some(scan);
+
+        self.token_estimator = TokenEstimator::from_config(&self.config);
+        self.preview_service = PreviewService::new();
+        self.exporter = Exporter::new()?;
+
+        if let Some(snapshot) = self.session_store.load()? {
+            self.restore_session(snapshot)?;
+        }
+
+        self.refresh_selection_state()?;
         Ok(())
+    }
+
+    fn event_loop(&mut self, terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+        loop {
+            terminal.draw(|frame| self.render(frame))?;
+            self.tick();
+
+            if self.should_quit {
+                break;
+            }
+
+            if event::poll(TICK_RATE)? {
+                let ev = event::read()?;
+                self.handle_event(ev)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>) {
+        let size = frame.size();
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(3), Constraint::Length(1)])
+            .split(size);
+
+        let main_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(32),
+                Constraint::Min(50),
+                Constraint::Length(36),
+            ])
+            .split(layout[0]);
+
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(10), Constraint::Length(5)])
+            .split(main_chunks[2]);
+
+        let focus_tree = matches!(self.focus, FocusTarget::FileTree);
+        let focus_preview = matches!(self.focus, FocusTarget::Preview);
+
+        let selected_paths = &self.selected_paths;
+        self.file_tree.render(
+            frame,
+            main_chunks[0],
+            &self.tree,
+            focus_tree,
+            selected_paths,
+        );
+
+        if let Some(segment) = self.preview.segment() {
+            self.preview_component().render(
+                segment,
+                self.preview.highlight_ranges(),
+                focus_preview,
+                main_chunks[1],
+                frame.buffer_mut(),
+            );
+        } else {
+            let block = Block::default()
+                .title("Preview")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(if focus_preview {
+                    Color::Cyan
+                } else {
+                    Color::DarkGray
+                }));
+            let inner = block.inner(main_chunks[1]);
+            frame.render_widget(block, main_chunks[1]);
+            let placeholder = Paragraph::new("Select a file to preview")
+                .style(
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::ITALIC),
+                )
+                .wrap(Wrap { trim: true });
+            frame.render_widget(placeholder, inner);
+        }
+
+        self.summary_component.render(frame, right_chunks[0]);
+
+        let hints = Paragraph::new(Line::from(vec![
+            Span::styled("j/k", Style::default().fg(Color::Cyan)),
+            Span::raw(" move "),
+            Span::styled("↵", Style::default().fg(Color::Cyan)),
+            Span::raw(" preview · "),
+            Span::styled("space", Style::default().fg(Color::Cyan)),
+            Span::raw(" toggle select · "),
+            Span::styled("/", Style::default().fg(Color::Cyan)),
+            Span::raw(" filter · "),
+            Span::styled(":", Style::default().fg(Color::Cyan)),
+            Span::raw(" palette · "),
+            Span::styled("ctrl+s", Style::default().fg(Color::Cyan)),
+            Span::raw(" save · "),
+            Span::styled("ctrl+e", Style::default().fg(Color::Cyan)),
+            Span::raw(" export"),
+        ]))
+        .wrap(Wrap { trim: true })
+        .style(Style::default().fg(Color::Gray));
+        frame.render_widget(hints, right_chunks[1]);
+
+        self.render_status(frame, layout[1]);
+        self.palette_component
+            .render(frame, size, &self.palette_state);
+    }
+
+    fn preview_component(&self) -> &Preview {
+        static PREVIEW: Preview = Preview;
+        &PREVIEW
+    }
+
+    fn render_status(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let message = self.status.as_ref().map(|status| {
+            let style = match status.level {
+                StatusLevel::Info => Style::default().fg(Color::Gray),
+                StatusLevel::Success => Style::default().fg(Color::Green),
+                StatusLevel::Error => Style::default().fg(Color::Red),
+            };
+            Line::styled(status.text.clone(), style)
+        });
+
+        let block = Block::default().borders(Borders::TOP);
+        frame.render_widget(block.clone(), area);
+        let inner = block.inner(area);
+
+        let line = message.unwrap_or_else(|| {
+            Line::styled(
+                "Ready · press : for commands",
+                Style::default().fg(Color::DarkGray),
+            )
+        });
+        frame.render_widget(Paragraph::new(line), inner);
+    }
+
+    fn tick(&mut self) {
+        if let Some(status) = &self.status
+            && status.is_expired()
+        {
+            self.status = None;
+        }
+        self.palette_state.purge_expired_messages();
+    }
+
+    fn handle_event(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::Key(key) => self.handle_key_event(key)?,
+            Event::Resize(..) => {}
+            Event::Mouse(_) => {}
+            Event::FocusGained | Event::FocusLost | Event::Paste(_) => {}
+        }
+        Ok(())
+    }
+
+    fn handle_key_event(&mut self, key: KeyEvent) -> Result<()> {
+        if self.palette_state.is_open() {
+            return self.handle_palette_key(key);
+        }
+
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('c') | KeyCode::Char('q') => {
+                    self.should_quit = true;
+                    return Ok(());
+                }
+                KeyCode::Char('s') => {
+                    self.save_session()?;
+                    return Ok(());
+                }
+                KeyCode::Char('e') => {
+                    self.perform_export(None, true)?;
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
+        match self.focus {
+            FocusTarget::FileTree => self.handle_tree_key(key),
+            FocusTarget::Preview => self.handle_preview_key(key),
+            FocusTarget::CommandPalette => Ok(()),
+        }
+    }
+
+    fn handle_tree_key(&mut self, key: KeyEvent) -> Result<()> {
+        if self.tree.is_filter_active() {
+            return self.handle_filter_input(key);
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.should_quit = true;
+            }
+            KeyCode::Char('/') => {
+                self.tree.begin_filter();
+            }
+            KeyCode::Char(':') => {
+                self.palette_state.open();
+                self.focus = FocusTarget::CommandPalette;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.tree.select_next();
+                self.preview_current(false)?;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.tree.select_previous();
+                self.preview_current(false)?;
+            }
+            KeyCode::Char('h') | KeyCode::Left => {
+                self.tree.collapse_or_parent();
+            }
+            KeyCode::Char('l') | KeyCode::Right => {
+                if self.preview_current(true)? {
+                    self.focus = FocusTarget::Preview;
+                } else {
+                    self.tree.expand_or_open();
+                }
+            }
+            KeyCode::Enter => {
+                if self.preview_current(true)? {
+                    self.focus = FocusTarget::Preview;
+                }
+            }
+            KeyCode::Char(' ') => {
+                self.toggle_current_selection()?;
+            }
+            KeyCode::Tab => {
+                self.focus = FocusTarget::Preview;
+            }
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_preview_key(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.preview.clear_anchor();
+                self.focus = FocusTarget::FileTree;
+            }
+            KeyCode::Char(':') => {
+                self.palette_state.open();
+                self.focus = FocusTarget::CommandPalette;
+            }
+            KeyCode::Char(' ') => {
+                self.toggle_current_selection()?;
+            }
+            KeyCode::Tab | KeyCode::Left => {
+                self.preview.clear_anchor();
+                self.focus = FocusTarget::FileTree;
+            }
+            KeyCode::Right => {
+                if self
+                    .preview
+                    .load_more(&self.preview_service, &self.config)?
+                {
+                    self.refresh_preview_highlights();
+                }
+            }
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let Some(change) = self
+                    .preview
+                    .move_cursor(-1, key.modifiers.contains(KeyModifiers::SHIFT))?
+                {
+                    self.apply_range_change(change)?;
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    if let Some(change) = self.preview.move_cursor(1, true)? {
+                        self.apply_range_change(change)?;
+                    }
+                } else {
+                    if self.preview.at_bottom()
+                        && self
+                            .preview
+                            .load_more(&self.preview_service, &self.config)?
+                    {
+                        self.refresh_preview_highlights();
+                    }
+                    if let Some(change) = self.preview.move_cursor(1, false)? {
+                        self.apply_range_change(change)?;
+                    }
+                }
+            }
+            KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.save_session()?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_palette_key(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.palette_state.close();
+                self.focus = FocusTarget::FileTree;
+            }
+            KeyCode::Enter => {
+                let command = self.palette_state.take_input();
+                self.palette_state.close();
+                self.focus = FocusTarget::FileTree;
+                if let Err(err) = self.execute_command(command.trim()) {
+                    self.set_status(StatusLevel::Error, err.to_string());
+                }
+            }
+            KeyCode::Backspace => {
+                self.palette_state.pop_char();
+            }
+            KeyCode::Char(ch) => {
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                {
+                    self.palette_state.push_char(ch);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_filter_input(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.tree.end_filter();
+            }
+            KeyCode::Enter => {
+                self.tree.end_filter();
+            }
+            KeyCode::Backspace => {
+                self.tree.pop_filter_char();
+            }
+            KeyCode::Char(ch) => {
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                {
+                    self.tree.push_filter_char(ch);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn preview_current(&mut self, force: bool) -> Result<bool> {
+        let metadata = match self.tree.selected_metadata() {
+            Some(meta) => meta,
+            None => return Ok(false),
+        };
+        if metadata.is_dir {
+            return Ok(false);
+        }
+
+        if metadata.skipped.is_some() {
+            self.set_status(
+                StatusLevel::Info,
+                format!("{} skipped during scan", metadata.display_path),
+            );
+            return Ok(false);
+        }
+
+        let already_previewing = self
+            .preview
+            .path()
+            .map(|path| path == metadata.path)
+            .unwrap_or(false);
+        if already_previewing && !force {
+            return Ok(true);
+        }
+
+        let segment = self
+            .preview_service
+            .preview(&metadata.path, None, &self.config)
+            .with_context(|| format!("failed to preview {}", metadata.display_path))?;
+
+        self.preview.set_segment(segment);
+        self.refresh_preview_highlights();
+        if force {
+            self.focus = FocusTarget::Preview;
+        }
+        Ok(true)
+    }
+
+    fn refresh_preview_highlights(&mut self) {
+        if let Some(path) = self.preview.path().map(PathBuf::from) {
+            let mut ranges = Vec::new();
+            for item in self.selection.items() {
+                if item.path == path {
+                    if let Some(range) = item.range {
+                        ranges.push(range);
+                    } else {
+                        ranges.push((1, usize::MAX));
+                    }
+                }
+            }
+            self.preview.set_highlights(ranges);
+        }
+    }
+
+    fn apply_range_change(&mut self, change: RangeChange) -> Result<()> {
+        let RangeChange {
+            path,
+            removed,
+            added,
+        } = change;
+        if let Some(range) = removed {
+            self.selection.remove_selection(&path, Some(range));
+        }
+        if let Some(range) = added {
+            self.selection
+                .add_selection(path.clone(), Some(range), None);
+        }
+        self.refresh_selection_state()
+    }
+
+    fn toggle_current_selection(&mut self) -> Result<()> {
+        let metadata = match self.tree.selected_metadata() {
+            Some(meta) => meta,
+            None => return Ok(()),
+        };
+        if metadata.is_dir {
+            return Ok(());
+        }
+
+        let existed = self.selection.remove_selection(&metadata.path, None);
+        if !existed {
+            self.selection
+                .add_selection(metadata.path.clone(), None, None);
+            self.set_status(
+                StatusLevel::Success,
+                format!("Added {}", metadata.display_path),
+            );
+        } else {
+            self.set_status(
+                StatusLevel::Info,
+                format!("Removed {}", metadata.display_path),
+            );
+        }
+        self.refresh_selection_state()?;
+        Ok(())
+    }
+
+    fn execute_command(&mut self, command: &str) -> Result<()> {
+        if command.is_empty() {
+            return Ok(());
+        }
+
+        let mut parts = command.split_whitespace();
+        let verb = parts.next().unwrap_or("");
+        let rest = command[verb.len()..].trim();
+
+        match verb {
+            "filter" => {
+                self.tree.set_filter(rest);
+                self.set_status(StatusLevel::Success, "Filter applied");
+            }
+            "clear" => {
+                if rest == "filter" || rest.is_empty() {
+                    self.tree.clear_filter();
+                    self.set_status(StatusLevel::Info, "Filter cleared");
+                }
+            }
+            "select" => {
+                let range = parse_range(rest).ok_or_else(|| anyhow!("invalid range"))?;
+                let segment = self
+                    .preview
+                    .segment()
+                    .ok_or_else(|| anyhow!("open a preview first"))?;
+                self.selection
+                    .add_selection(segment.path.clone(), Some(range), None);
+                self.set_status(
+                    StatusLevel::Success,
+                    format!(
+                        "Selected {}:{}-{}",
+                        segment.path.display(),
+                        range.0,
+                        range.1
+                    ),
+                );
+                self.refresh_selection_state()?;
+            }
+            "export" => {
+                if rest.is_empty() {
+                    self.perform_export(None, true)?;
+                } else {
+                    self.perform_export(Some(PathBuf::from(rest)), true)?;
+                }
+            }
+            "save" => {
+                self.save_session()?;
+            }
+            "model" => {
+                if rest.is_empty() {
+                    return Err(anyhow!("model command requires an identifier"));
+                }
+                self.selection.set_model(rest.to_string());
+                self.refresh_selection_state()?;
+                self.set_status(StatusLevel::Success, format!("Model set to {rest}"));
+            }
+            "help" => {
+                self.set_status(
+                    StatusLevel::Info,
+                    "Commands: filter, select <start-end>, export [path], save, model <id>",
+                );
+            }
+            other => {
+                return Err(anyhow!("unknown command '{other}'"));
+            }
+        }
+        Ok(())
+    }
+
+    fn perform_export(&mut self, target: Option<PathBuf>, copy: bool) -> Result<()> {
+        if self.selection.is_empty() {
+            self.set_status(StatusLevel::Error, "No selections to export");
+            return Ok(());
+        }
+
+        let mut options = ExportOptions::from_config(&self.config);
+        options.copy_to_clipboard = copy;
+
+        let path = if let Some(path) = target {
+            path
+        } else {
+            let snapshot = self
+                .session_store
+                .path()
+                .parent()
+                .map(|dir| dir.join("exports"))
+                .unwrap_or_else(|| PathBuf::from(".llmctx/exports"));
+            fs::create_dir_all(&snapshot).context("failed to create export directory")?;
+            let timestamp = OffsetDateTime::now_utc().format(format_description!(
+                "[year][month][day]-[hour][minute][second]"
+            ))?;
+            snapshot.join(format!(
+                "context-{timestamp}.{}",
+                options.format.extension()
+            ))
+        };
+        options.output_path = Some(path.clone());
+
+        let summary = self.selection.summarize_tokens(&self.token_estimator)?;
+        if let Some(ref data) = summary {
+            self.summary_component.update(data.clone());
+            self.last_summary = Some(data.clone());
+        }
+
+        let bundle = self.selection.to_bundle();
+        self.exporter.export(&bundle, summary.as_ref(), &options)?;
+
+        self.set_status(
+            StatusLevel::Success,
+            format!("Exported selection to {}", path.display()),
+        );
+        Ok(())
+    }
+
+    fn save_session(&mut self) -> Result<()> {
+        let root = self
+            .scan
+            .as_ref()
+            .map(|scan| scan.root.clone())
+            .unwrap_or_else(|| PathBuf::from("."));
+        let selections: Vec<SelectionRecord> = self
+            .selection
+            .items()
+            .iter()
+            .map(|item| {
+                let mut record = SelectionRecord::from(item);
+                if let Ok(relative) = item.path.strip_prefix(&root) {
+                    record.path = relative.display().to_string();
+                }
+                record
+            })
+            .collect();
+        let focused = self
+            .tree
+            .selected_metadata()
+            .map(|meta| meta.display_path.clone());
+        let filter = if self.tree.filter().is_empty() {
+            None
+        } else {
+            Some(self.tree.filter().to_string())
+        };
+        let snapshot = SessionSnapshot {
+            selections,
+            focused_path: focused,
+            filter,
+            model: self.selection.model().map(ToString::to_string),
+        };
+        self.session_store.save(&snapshot)?;
+        self.set_status(StatusLevel::Success, "Session saved");
+        Ok(())
+    }
+
+    fn restore_session(&mut self, snapshot: SessionSnapshot) -> Result<()> {
+        if let Some(model) = snapshot.model {
+            self.selection.set_model(model);
+        }
+        let root = self
+            .scan
+            .as_ref()
+            .map(|scan| scan.root.clone())
+            .unwrap_or_else(|| PathBuf::from("."));
+        for record in snapshot.selections {
+            let mut item = record.into_selection_item();
+            if item.path.is_relative() {
+                item.path = root.join(item.path);
+            }
+            self.selection
+                .add_selection(item.path.clone(), item.range, item.note.clone());
+        }
+        if let Some(filter) = snapshot.filter {
+            self.tree.set_filter(filter);
+        }
+        if let Some(path) = snapshot.focused_path {
+            self.tree.focus_path(&path);
+            self.preview_current(false)?;
+        }
+        Ok(())
+    }
+
+    fn refresh_selection_state(&mut self) -> Result<()> {
+        self.rebuild_selected_paths();
+        self.refresh_preview_highlights();
+
+        match self.selection.summarize_tokens(&self.token_estimator)? {
+            Some(summary) => {
+                self.summary_component.update(summary.clone());
+                self.last_summary = Some(summary);
+            }
+            None => {
+                self.summary_component.clear();
+                self.last_summary = None;
+            }
+        }
+        Ok(())
+    }
+
+    fn rebuild_selected_paths(&mut self) {
+        self.selected_paths.clear();
+        let root = self
+            .scan
+            .as_ref()
+            .map(|scan| scan.root.clone())
+            .unwrap_or_else(|| PathBuf::from("."));
+        for item in self.selection.items() {
+            let display = self
+                .path_lookup
+                .get(&item.path)
+                .cloned()
+                .unwrap_or_else(|| path_relative_to(&item.path, &root));
+            self.selected_paths.insert(display);
+        }
+    }
+
+    fn set_status<S: Into<String>>(&mut self, level: StatusLevel, message: S) {
+        self.status = Some(StatusMessage::new(level, message.into()));
+    }
+}
+
+fn path_relative_to(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn parse_range(input: &str) -> Option<(usize, usize)> {
+    let (start, end) = input.split_once('-')?;
+    let start = start.trim().parse().ok()?;
+    let end = end.trim().parse().ok()?;
+    Some((start, end))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FocusTarget {
+    FileTree,
+    Preview,
+    CommandPalette,
+}
+
+#[derive(Debug)]
+struct StatusMessage {
+    level: StatusLevel,
+    text: String,
+    expires_at: Instant,
+}
+
+impl StatusMessage {
+    fn new(level: StatusLevel, text: String) -> Self {
+        Self {
+            level,
+            text,
+            expires_at: Instant::now() + Duration::from_secs(4),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StatusLevel {
+    Info,
+    Success,
+    Error,
+}
+
+#[derive(Debug, Default)]
+struct PreviewState {
+    segment: Option<PreviewSegment>,
+    cursor: Option<usize>,
+    anchor: Option<usize>,
+    highlights: Vec<(usize, usize)>,
+    active_range: Option<(usize, usize)>,
+    active_path: Option<PathBuf>,
+}
+
+impl PreviewState {
+    fn segment(&self) -> Option<&PreviewSegment> {
+        self.segment.as_ref()
+    }
+
+    fn set_segment(&mut self, segment: PreviewSegment) {
+        self.cursor = Some(segment.start_line);
+        self.anchor = None;
+        self.segment = Some(segment);
+        self.active_range = None;
+        self.active_path = None;
+    }
+
+    fn set_highlights(&mut self, highlights: Vec<(usize, usize)>) {
+        self.highlights = highlights;
+    }
+
+    fn highlight_ranges(&self) -> &[(usize, usize)] {
+        &self.highlights
+    }
+
+    fn path(&self) -> Option<&Path> {
+        self.segment.as_ref().map(|segment| segment.path.as_path())
+    }
+
+    fn load_more(&mut self, service: &PreviewService, config: &Config) -> Result<bool> {
+        let segment = match &self.segment {
+            Some(segment) => segment.clone(),
+            None => return Ok(false),
+        };
+        let token = match segment.continuation.clone() {
+            Some(token) => token,
+            None => return Ok(false),
+        };
+        let mut step = config.defaults.preview_max_lines();
+        if step == 0 {
+            step = 200;
+        }
+        let range = token.start_line..token.start_line + step;
+        let next = service.preview(&segment.path, Some(range), config)?;
+        self.cursor = Some(next.start_line);
+        self.anchor = None;
+        self.segment = Some(next);
+        self.active_range = None;
+        self.active_path = None;
+        Ok(true)
+    }
+
+    fn move_cursor(&mut self, delta: isize, extend: bool) -> Result<Option<RangeChange>> {
+        let segment = match &self.segment {
+            Some(segment) => segment.clone(),
+            None => return Ok(None),
+        };
+        let mut cursor = self.cursor.unwrap_or(segment.start_line);
+        let prev_cursor = cursor;
+        let min = segment.start_line;
+        let max = segment.end_line.max(segment.start_line);
+        cursor = cursor.saturating_add_signed(delta);
+        cursor = cursor.clamp(min, max);
+
+        if extend {
+            let anchor = self.anchor.unwrap_or(prev_cursor);
+            self.anchor = Some(anchor);
+            let range = if cursor >= anchor {
+                (anchor, cursor)
+            } else {
+                (cursor, anchor)
+            };
+            let path = segment.path.clone();
+            if self.active_path.as_ref() != Some(&path) {
+                self.active_path = Some(path.clone());
+                self.active_range = None;
+            }
+            let change = RangeChange {
+                path,
+                removed: self.active_range,
+                added: Some(range),
+            };
+            self.active_range = Some(range);
+            self.cursor = Some(cursor);
+            return Ok(Some(change));
+        } else {
+            self.anchor = None;
+            self.active_range = None;
+        }
+
+        self.cursor = Some(cursor);
+        Ok(None)
+    }
+
+    fn clear_anchor(&mut self) {
+        self.anchor = None;
+        self.active_range = None;
+    }
+
+    fn at_bottom(&self) -> bool {
+        match (&self.segment, self.cursor) {
+            (Some(segment), Some(cursor)) => cursor >= segment.end_line,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RangeChange {
+    path: PathBuf,
+    removed: Option<(usize, usize)>,
+    added: Option<(usize, usize)>,
+}
+
+impl TokenEstimator {
+    fn default() -> Self {
+        TokenEstimator::from_config(&Config::default())
     }
 }

--- a/crates/llmctx/src/ui/components/command_palette.rs
+++ b/crates/llmctx/src/ui/components/command_palette.rs
@@ -1,6 +1,170 @@
-//! Command palette component placeholder.
+//! Command palette component for quick actions.
 
-#[derive(Default)]
+use std::time::{Duration, Instant};
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+/// Interactive state backing the command palette overlay.
+#[derive(Debug, Default, Clone)]
+pub struct CommandPaletteState {
+    visible: bool,
+    input: String,
+    message: Option<PaletteMessage>,
+}
+
+impl CommandPaletteState {
+    /// Reveal the palette with an empty input buffer.
+    pub fn open(&mut self) {
+        self.visible = true;
+        self.input.clear();
+    }
+
+    /// Reveal the palette with an initial command prefilled.
+    pub fn open_with<S: Into<String>>(&mut self, content: S) {
+        self.visible = true;
+        self.input = content.into();
+    }
+
+    /// Hide the palette.
+    pub fn close(&mut self) {
+        self.visible = false;
+    }
+
+    /// Whether the palette is currently displayed.
+    pub fn is_open(&self) -> bool {
+        self.visible
+    }
+
+    /// Access the current input buffer.
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Replace the current input contents.
+    pub fn set_input<S: Into<String>>(&mut self, content: S) {
+        self.input = content.into();
+    }
+
+    /// Consume the current input, leaving the buffer empty.
+    pub fn take_input(&mut self) -> String {
+        std::mem::take(&mut self.input)
+    }
+
+    /// Append a character to the buffer.
+    pub fn push_char(&mut self, ch: char) {
+        self.input.push(ch);
+    }
+
+    /// Remove the most recently appended character if present.
+    pub fn pop_char(&mut self) {
+        self.input.pop();
+    }
+
+    /// Record a status message to display beneath the input field.
+    pub fn set_message<S: Into<String>>(&mut self, level: PaletteMessageLevel, message: S) {
+        self.message = Some(PaletteMessage::new(level, message.into()));
+    }
+
+    /// Clear any displayed message.
+    pub fn clear_message(&mut self) {
+        self.message = None;
+    }
+
+    /// Retain only messages that have not expired.
+    pub fn purge_expired_messages(&mut self) {
+        if let Some(message) = &self.message
+            && message.is_expired()
+        {
+            self.message = None;
+        }
+    }
+}
+
+/// Visual component that renders the command palette overlay.
+#[derive(Debug, Default)]
 pub struct CommandPalette;
 
-impl CommandPalette {}
+impl CommandPalette {
+    /// Draw the palette if it is visible.
+    pub fn render(&self, frame: &mut Frame<'_>, area: Rect, state: &CommandPaletteState) {
+        if !state.is_open() {
+            return;
+        }
+
+        let width = area.width.saturating_sub(10).min(80);
+        let popup = Rect {
+            x: area.x + (area.width - width) / 2,
+            y: area.y + area.height.saturating_sub(6),
+            width,
+            height: 5,
+        };
+
+        frame.render_widget(Clear, popup);
+
+        let block = Block::default()
+            .title("Command Palette")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan));
+        frame.render_widget(block.clone(), popup);
+
+        let inner = block.inner(popup);
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(2), Constraint::Min(0)])
+            .split(inner);
+
+        let prompt = Paragraph::new(format!(":{}", state.input()))
+            .style(Style::default().fg(Color::White))
+            .block(Block::default());
+        frame.render_widget(prompt, layout[0]);
+
+        if let Some(message) = &state.message {
+            let style = match message.level {
+                PaletteMessageLevel::Info => Style::default().fg(Color::Gray),
+                PaletteMessageLevel::Success => Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+                PaletteMessageLevel::Error => {
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+                }
+            };
+            let paragraph = Paragraph::new(Line::from(message.text.clone()))
+                .wrap(Wrap { trim: true })
+                .style(style);
+            frame.render_widget(paragraph, layout[1]);
+        }
+    }
+}
+
+/// Command palette message severity levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaletteMessageLevel {
+    Info,
+    Success,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+struct PaletteMessage {
+    level: PaletteMessageLevel,
+    text: String,
+    expires_at: Instant,
+}
+
+impl PaletteMessage {
+    fn new(level: PaletteMessageLevel, text: String) -> Self {
+        Self {
+            level,
+            text,
+            expires_at: Instant::now() + Duration::from_secs(4),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}

--- a/crates/llmctx/src/ui/components/file_tree.rs
+++ b/crates/llmctx/src/ui/components/file_tree.rs
@@ -1,6 +1,560 @@
-//! File tree component placeholder.
+//! File tree component and state management.
 
-#[derive(Default)]
+use std::collections::{HashMap, HashSet};
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+use crate::app::scan::{FileMetadata, ScanResult, SkipReason};
+
+/// Maintains the navigable state of the file tree.
+#[derive(Debug, Default, Clone)]
+pub struct FileTreeState {
+    entries: Vec<TreeEntry>,
+    visible: Vec<usize>,
+    selected: usize,
+    expanded: HashSet<String>,
+    filter: String,
+    filter_active: bool,
+    root_label: String,
+}
+
+impl FileTreeState {
+    /// Construct state from a scan result.
+    pub fn from_scan(result: &ScanResult) -> Self {
+        let mut state = Self {
+            entries: Vec::new(),
+            visible: Vec::new(),
+            selected: 0,
+            expanded: HashSet::new(),
+            filter: String::new(),
+            filter_active: false,
+            root_label: result
+                .root
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| result.root.display().to_string()),
+        };
+        state.rebuild_entries(result);
+        state
+    }
+
+    fn rebuild_entries(&mut self, result: &ScanResult) {
+        let mut entries = Vec::with_capacity(result.files.len());
+        let mut index_map: HashMap<String, usize> = HashMap::new();
+
+        for meta in &result.files {
+            let key = meta.display_path.clone();
+            let depth = meta.display_path.matches('/').count();
+            let name = display_name(&meta.display_path);
+            let parent_key = parent_key(&meta.display_path);
+            let parent = parent_key.as_ref().and_then(|p| index_map.get(p).copied());
+
+            let entry = TreeEntry {
+                metadata: meta.clone(),
+                name,
+                depth,
+                parent,
+                has_children: false,
+            };
+            let idx = entries.len();
+            entries.push(entry);
+            index_map.insert(key.clone(), idx);
+
+            if let Some(parent_idx) = parent
+                && let Some(parent_entry) = entries.get_mut(parent_idx)
+            {
+                parent_entry.has_children = true;
+            }
+        }
+
+        // Expand first level directories by default for better discoverability.
+        self.expanded.clear();
+        for entry in &entries {
+            if entry.depth == 0 && entry.metadata.is_dir {
+                self.expanded.insert(entry.metadata.display_path.clone());
+            }
+        }
+
+        self.entries = entries;
+        self.visible.clear();
+        self.selected = 0;
+        self.refresh_visible();
+    }
+
+    /// Provide read-only access to the currently selected metadata.
+    pub fn selected_metadata(&self) -> Option<&FileMetadata> {
+        self.visible
+            .get(self.selected)
+            .and_then(|idx| self.entries.get(*idx))
+            .map(|entry| &entry.metadata)
+    }
+
+    /// Highlight the provided path if it exists in the tree.
+    pub fn focus_path(&mut self, display_path: &str) {
+        if let Some((index, _)) = self
+            .entries
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| entry.metadata.display_path == display_path)
+        {
+            self.expand_to(index);
+        }
+    }
+
+    fn expand_to(&mut self, index: usize) {
+        let mut cursor = Some(index);
+        while let Some(idx) = cursor {
+            if let Some(entry) = self.entries.get(idx) {
+                if entry.metadata.is_dir {
+                    self.expanded.insert(entry.metadata.display_path.clone());
+                }
+                cursor = entry.parent;
+            } else {
+                break;
+            }
+        }
+
+        self.refresh_visible();
+        if let Some(pos) = self.visible.iter().position(|idx| *idx == index) {
+            self.selected = pos;
+        }
+    }
+
+    /// Advance selection to the next item if possible.
+    pub fn select_next(&mut self) {
+        if self.selected + 1 < self.visible.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Move selection to the previous item if possible.
+    pub fn select_previous(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+    }
+
+    /// Expand the currently selected directory or activate its first child.
+    pub fn expand_or_open(&mut self) {
+        if let Some(index) = self.selected_entry_index()
+            && self.entries[index].metadata.is_dir
+        {
+            let key = self.entries[index].metadata.display_path.clone();
+            if !self.expanded.insert(key.clone()) {
+                if let Some(first_child) = self.visible.iter().position(|idx| {
+                    self.entries.get(*idx).and_then(|item| item.parent) == Some(index)
+                }) {
+                    self.selected = first_child;
+                }
+            } else {
+                self.refresh_visible();
+            }
+        }
+    }
+
+    /// Collapse the selected directory or move focus to its parent.
+    pub fn collapse_or_parent(&mut self) {
+        if let Some(index) = self.selected_entry_index() {
+            let key = self.entries[index].metadata.display_path.clone();
+            let parent = self.entries[index].parent;
+            let is_dir = self.entries[index].metadata.is_dir;
+            if is_dir && self.expanded.remove(&key) {
+                self.refresh_visible();
+            } else if let Some(parent_idx) = parent
+                && let Some(pos) = self.visible.iter().position(|idx| *idx == parent_idx)
+            {
+                self.selected = pos;
+            }
+        }
+    }
+
+    /// Toggle the expansion state of the selected directory.
+    pub fn toggle_expansion(&mut self) {
+        if let Some(index) = self.selected_entry_index()
+            && self.entries[index].metadata.is_dir
+        {
+            let key = self.entries[index].metadata.display_path.clone();
+            if !self.expanded.remove(&key) {
+                self.expanded.insert(key);
+            }
+            self.refresh_visible();
+        }
+    }
+
+    /// Activate incremental filter editing.
+    pub fn begin_filter(&mut self) {
+        self.filter_active = true;
+    }
+
+    /// Deactivate the filter editing mode.
+    pub fn end_filter(&mut self) {
+        self.filter_active = false;
+    }
+
+    /// Whether filter mode is currently active.
+    pub fn is_filter_active(&self) -> bool {
+        self.filter_active
+    }
+
+    /// Append a character to the filter string and refresh visibility.
+    pub fn push_filter_char(&mut self, ch: char) {
+        self.filter.push(ch);
+        self.refresh_visible();
+    }
+
+    /// Remove the most recent filter character.
+    pub fn pop_filter_char(&mut self) {
+        self.filter.pop();
+        self.refresh_visible();
+    }
+
+    /// Clear the active filter.
+    pub fn clear_filter(&mut self) {
+        if !self.filter.is_empty() {
+            self.filter.clear();
+            self.refresh_visible();
+        }
+    }
+
+    /// Replace the filter contents.
+    pub fn set_filter<S: Into<String>>(&mut self, pattern: S) {
+        self.filter = pattern.into();
+        self.refresh_visible();
+    }
+
+    /// Retrieve the active filter string.
+    pub fn filter(&self) -> &str {
+        &self.filter
+    }
+
+    fn refresh_visible(&mut self) {
+        self.visible.clear();
+        if self.entries.is_empty() {
+            return;
+        }
+
+        let lower_filter = self.filter.to_ascii_lowercase();
+        let mut matches = vec![lower_filter.is_empty(); self.entries.len()];
+
+        if !lower_filter.is_empty() {
+            for (idx, entry) in self.entries.iter().enumerate() {
+                if entry
+                    .metadata
+                    .display_path
+                    .to_ascii_lowercase()
+                    .contains(&lower_filter)
+                {
+                    matches[idx] = true;
+                    let mut parent = entry.parent;
+                    while let Some(p) = parent {
+                        matches[p] = true;
+                        parent = self.entries[p].parent;
+                    }
+                }
+            }
+        }
+
+        for (idx, entry) in self.entries.iter().enumerate() {
+            if !matches[idx] {
+                continue;
+            }
+            if self.ancestors_expanded(idx, &matches) {
+                self.visible.push(idx);
+            }
+
+            if entry.metadata.is_dir && !self.filter.is_empty() {
+                self.expanded.insert(entry.metadata.display_path.clone());
+            }
+        }
+
+        if self.selected >= self.visible.len() {
+            self.selected = self.visible.len().saturating_sub(1);
+        }
+    }
+
+    fn ancestors_expanded(&self, mut idx: usize, matches: &[bool]) -> bool {
+        while let Some(parent_idx) = self.entries[idx].parent {
+            let parent = &self.entries[parent_idx];
+            if !parent.metadata.is_dir {
+                idx = parent_idx;
+                continue;
+            }
+            if !self.is_expanded(parent_idx, matches) {
+                return false;
+            }
+            idx = parent_idx;
+        }
+        true
+    }
+
+    fn is_expanded(&self, idx: usize, matches: &[bool]) -> bool {
+        let key = &self.entries[idx].metadata.display_path;
+        if !self.filter.is_empty() && matches[idx] {
+            true
+        } else {
+            self.expanded.contains(key)
+        }
+    }
+
+    fn selected_entry_index(&self) -> Option<usize> {
+        self.visible.get(self.selected).copied()
+    }
+
+    /// Iterate over entries that should be displayed in the UI.
+    fn iter_visible(&self) -> impl Iterator<Item = (usize, usize, &TreeEntry)> {
+        self.visible
+            .iter()
+            .enumerate()
+            .filter_map(|(display_idx, entry_idx)| {
+                self.entries
+                    .get(*entry_idx)
+                    .map(|entry| (display_idx, *entry_idx, entry))
+            })
+    }
+
+    /// Index of the currently highlighted item within the visible list.
+    pub fn selected_index(&self) -> Option<usize> {
+        if self.visible.is_empty() {
+            None
+        } else {
+            Some(self.selected)
+        }
+    }
+
+    /// Number of items currently visible in the file tree.
+    pub fn visible_len(&self) -> usize {
+        self.visible.len()
+    }
+
+    /// Whether a path is currently expanded.
+    pub fn is_path_expanded(&self, path: &str) -> bool {
+        self.expanded.contains(path)
+    }
+
+    /// Expose the root label for rendering.
+    pub fn root_label(&self) -> &str {
+        &self.root_label
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TreeEntry {
+    metadata: FileMetadata,
+    name: String,
+    depth: usize,
+    parent: Option<usize>,
+    has_children: bool,
+}
+
+/// Ratatui component responsible for rendering the file tree view.
+#[derive(Debug, Default)]
 pub struct FileTree;
 
-impl FileTree {}
+impl FileTree {
+    /// Render the file tree to the provided frame.
+    pub fn render(
+        &self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        state: &FileTreeState,
+        has_focus: bool,
+        selected_paths: &HashSet<String>,
+    ) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!("Workspace · {}", state.root_label()));
+        frame.render_widget(block.clone(), area);
+
+        let inner = block.inner(area);
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .split(inner);
+
+        let filter_text = if state.filter().is_empty() {
+            "⌕ filter (press /)".to_string()
+        } else {
+            format!("⌕ {}", state.filter())
+        };
+
+        let mut filter_style = Style::default().fg(Color::Gray);
+        if state.is_filter_active() {
+            filter_style = filter_style.add_modifier(Modifier::BOLD).fg(Color::Cyan);
+        }
+
+        let filter_line = Paragraph::new(filter_text).style(filter_style);
+        frame.render_widget(filter_line, layout[0]);
+
+        if state.visible_len() == 0 {
+            let placeholder = Paragraph::new("No files match filter").style(
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            );
+            frame.render_widget(placeholder, layout[1]);
+            return;
+        }
+
+        let mut items = Vec::with_capacity(state.visible_len());
+        for (display_idx, _index, entry) in state.iter_visible() {
+            let mut spans = Vec::new();
+            spans.push(Span::raw("  ".repeat(entry.depth)));
+
+            if entry.metadata.is_dir {
+                let symbol = if state.is_path_expanded(&entry.metadata.display_path) {
+                    "▾"
+                } else if entry.has_children {
+                    "▸"
+                } else {
+                    "·"
+                };
+                spans.push(Span::styled(
+                    format!("{} ", symbol),
+                    Style::default().fg(Color::Yellow),
+                ));
+            } else {
+                spans.push(Span::styled("• ", Style::default().fg(Color::Gray)));
+            }
+
+            let mut name_style = Style::default();
+            if selected_paths.contains(&entry.metadata.display_path) {
+                name_style = name_style.fg(Color::Cyan).add_modifier(Modifier::BOLD);
+            }
+
+            if let Some(reason) = entry.metadata.skipped {
+                let label = match reason {
+                    SkipReason::LargeFile => "(large)",
+                    SkipReason::BinaryFile => "(binary)",
+                };
+                spans.push(Span::styled(
+                    entry.name.clone(),
+                    name_style.fg(Color::DarkGray),
+                ));
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled(label, Style::default().fg(Color::Yellow)));
+            } else {
+                spans.push(Span::styled(entry.name.clone(), name_style));
+            }
+
+            let line = Line::from(spans);
+            let mut item = ListItem::new(line);
+            if display_idx % 2 == 1 {
+                item = item.style(Style::default().bg(Color::Rgb(24, 24, 24)));
+            }
+            items.push(item);
+        }
+
+        let mut list_state = ratatui::widgets::ListState::default();
+        if let Some(selected) = state.selected_index() {
+            list_state.select(Some(selected));
+        }
+
+        let highlight_style = if has_focus {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Gray)
+                .add_modifier(Modifier::BOLD)
+        };
+
+        let list = List::new(items)
+            .block(Block::default())
+            .highlight_style(highlight_style)
+            .highlight_symbol("▸ ");
+
+        frame.render_stateful_widget(list, layout[1], &mut list_state);
+    }
+}
+
+fn display_name(display_path: &str) -> String {
+    std::path::Path::new(display_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| display_path.to_string())
+}
+
+fn parent_key(display_path: &str) -> Option<String> {
+    std::path::Path::new(display_path)
+        .parent()
+        .and_then(|parent| {
+            if parent.as_os_str().is_empty() {
+                None
+            } else {
+                Some(parent.to_string_lossy().to_string())
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use crate::app::scan::{FileMetadata, ScanResult};
+
+    #[test]
+    fn renders_tree_for_basic_scan() {
+        let backend = TestBackend::new(60, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let scan = sample_scan();
+        let state = FileTreeState::from_scan(&scan);
+        let component = FileTree;
+        let selected = HashSet::new();
+
+        terminal
+            .draw(|frame| {
+                let area = frame.size();
+                component.render(frame, area, &state, true, &selected);
+            })
+            .unwrap();
+    }
+
+    fn sample_scan() -> ScanResult {
+        let root = PathBuf::from("/tmp/workspace");
+        let files = vec![
+            FileMetadata {
+                path: root.join("src"),
+                display_path: "src".into(),
+                is_dir: true,
+                size: None,
+                modified: None,
+                language: None,
+                skipped: None,
+            },
+            FileMetadata {
+                path: root.join("src/lib.rs"),
+                display_path: "src/lib.rs".into(),
+                is_dir: false,
+                size: Some(42),
+                modified: None,
+                language: Some("rust".into()),
+                skipped: None,
+            },
+            FileMetadata {
+                path: root.join("README.md"),
+                display_path: "README.md".into(),
+                is_dir: false,
+                size: Some(10),
+                modified: None,
+                language: Some("markdown".into()),
+                skipped: None,
+            },
+        ];
+
+        ScanResult { files, root }
+    }
+}


### PR DESCRIPTION
## Summary
- add a full-screen ratatui application with file tree navigation, preview, selection summary, and command/status overlays
- wire command palette actions for filtering, range selection, exporting, session persistence, and model switching
- persist session state to disk and document the interactive workflow and shortcuts in the README

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features
- cargo test

Closes https://github.com/Jbolt01/llmctx/issues/8.

------
https://chatgpt.com/codex/tasks/task_e_68d3953b359c8322888fa1599aade123