### PR TITLE
ci: enhance test automation pipeline

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,19 @@
+[profile.default]
+fail-fast = false
+retries = 0
+
+[profile.ci]
+fail-fast = false
+status-level = "fail"
+final-status-level = "fail"
+slow-timeout = { period = "60s", terminate-after = 2 }
+retries = 1
+test-threads = "num-cpus"
+leak-detection = "warn"
+failure-output = "final"
+success-output = "never"
+
+[profile.local]
+fail-fast = false
+retries = 1
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
   governance-test:
     name: Test Suite
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 40
     needs: governance-lint
     strategy:
       matrix:
-        profile: [dev, release]
+        profile: [dev, release, nextest]
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -99,6 +99,9 @@ jobs:
         run: |
           if ! command -v cargo2junit >/dev/null 2>&1; then
             cargo install cargo2junit --locked
+          fi
+          if ! command -v cargo-nextest >/dev/null 2>&1; then
+            cargo install cargo-nextest --locked
           fi
       - name: Prepare integration fixtures
         run: |
@@ -120,6 +123,11 @@ jobs:
           cargo test --all-features --release --no-fail-fast -- --format json --report-time \
             | tee target/cargo-test-release.json \
             | cargo2junit > target/release-junit.xml
+      - name: Run tests (nextest)
+        if: matrix.profile == 'nextest'
+        run: |
+          cargo nextest run --profile ci --workspace --tests --examples --cargo-profile release \
+            --junit-output target/nextest-junit.xml
       - name: Archive test logs
         if: failure()
         uses: actions/upload-artifact@v4
@@ -128,6 +136,7 @@ jobs:
           path: |
             target/cargo-test-${{ matrix.profile }}.json
             target/${{ matrix.profile }}-junit.xml
+            target/nextest-junit.xml
           if-no-files-found: ignore
       - name: Upload junit report
         if: always()
@@ -140,15 +149,25 @@ jobs:
         run: |
           {
             echo "## Test summary (${{ matrix.profile }})";
-            if [ "${{ matrix.profile }}" = "dev" ]; then
-              echo "- cargo test --all-features --no-fail-fast -- --format json --report-time";
-              echo "- raw log: cargo-test-dev.json";
-              echo "- junit artifact: junit-dev";
-            else
-              echo "- cargo test --all-features --release --no-fail-fast -- --format json --report-time";
-              echo "- raw log: cargo-test-release.json";
-              echo "- junit artifact: junit-release";
-            fi;
+            case "${{ matrix.profile }}" in
+              dev)
+                echo "- cargo test --all-features --no-fail-fast -- --format json --report-time";
+                echo "- raw log: cargo-test-dev.json";
+                echo "- junit artifact: junit-dev";
+                echo "- coverage: grcov (debug profile)";
+                ;;
+              release)
+                echo "- cargo test --all-features --release --no-fail-fast -- --format json --report-time";
+                echo "- raw log: cargo-test-release.json";
+                echo "- junit artifact: junit-release";
+                echo "- coverage: grcov (release mapping)";
+                ;;
+              nextest)
+                echo "- cargo nextest run --profile ci --cargo-profile release";
+                echo "- junit artifact: junit-nextest";
+                echo "- targeted retries: nextest per-profile settings";
+                ;;
+            esac
           } >> "$GITHUB_STEP_SUMMARY"
 
   governance-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,30 +111,30 @@ jobs:
         if: matrix.profile == 'dev'
         run: |
           set -eo pipefail
-          cargo test --all-features --no-fail-fast -- --format json --report-time \
-            | tee target/cargo-test-dev.json \
-            | cargo2junit > target/dev-junit.xml
+          cargo test --all-features --no-fail-fast
       - name: Run tests (release profile)
         if: matrix.profile == 'release'
         env:
           RUSTFLAGS: "-C debuginfo=0"
         run: |
           set -eo pipefail
-          cargo test --all-features --release --no-fail-fast -- --format json --report-time \
-            | tee target/cargo-test-release.json \
-            | cargo2junit > target/release-junit.xml
+          cargo test --all-features --release --no-fail-fast
       - name: Run tests (nextest)
         if: matrix.profile == 'nextest'
+        env:
+          NEXTEST_PROFILE: ci
+          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
         run: |
-          cargo nextest run --profile ci --workspace --tests --examples --cargo-profile release \
-            --junit-output target/nextest-junit.xml
+          set -eo pipefail
+          cargo nextest run --profile ci --workspace --tests --examples --cargo-profile release
+          cargo nextest run --profile ci --workspace --tests --examples --cargo-profile release --message-format libtest-json \
+            | cargo2junit > target/nextest-junit.xml
       - name: Archive test logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-logs-${{ matrix.profile }}
           path: |
-            target/cargo-test-${{ matrix.profile }}.json
             target/${{ matrix.profile }}-junit.xml
             target/nextest-junit.xml
           if-no-files-found: ignore
@@ -151,16 +151,12 @@ jobs:
             echo "## Test summary (${{ matrix.profile }})";
             case "${{ matrix.profile }}" in
               dev)
-                echo "- cargo test --all-features --no-fail-fast -- --format json --report-time";
-                echo "- raw log: cargo-test-dev.json";
-                echo "- junit artifact: junit-dev";
-                echo "- coverage: grcov (debug profile)";
+                echo "- cargo test --all-features --no-fail-fast";
+                echo "- raw log: cargo-test-dev.log";
                 ;;
               release)
-                echo "- cargo test --all-features --release --no-fail-fast -- --format json --report-time";
-                echo "- raw log: cargo-test-release.json";
-                echo "- junit artifact: junit-release";
-                echo "- coverage: grcov (release mapping)";
+                echo "- cargo test --all-features --release --no-fail-fast";
+                echo "- raw log: cargo-test-release.log";
                 ;;
               nextest)
                 echo "- cargo nextest run --profile ci --cargo-profile release";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,11 @@ jobs:
   governance-test:
     name: Test Suite
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     needs: governance-lint
+    strategy:
+      matrix:
+        profile: [dev, release]
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -91,13 +94,61 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - name: Run tests
-        run: cargo test --all-features
+          shared-key: test-${{ matrix.profile }}
+      - name: Install tooling
+        run: |
+          if ! command -v cargo2junit >/dev/null 2>&1; then
+            cargo install cargo2junit --locked
+          fi
+      - name: Prepare integration fixtures
+        run: |
+          mkdir -p target/test-fixtures
+          echo "{}" > target/test-fixtures/default-config.json
+      - name: Run tests (dev profile)
+        if: matrix.profile == 'dev'
+        run: |
+          set -eo pipefail
+          cargo test --all-features --no-fail-fast -- --format json --report-time \
+            | tee target/cargo-test-dev.json \
+            | cargo2junit > target/dev-junit.xml
+      - name: Run tests (release profile)
+        if: matrix.profile == 'release'
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
+        run: |
+          set -eo pipefail
+          cargo test --all-features --release --no-fail-fast -- --format json --report-time \
+            | tee target/cargo-test-release.json \
+            | cargo2junit > target/release-junit.xml
+      - name: Archive test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.profile }}
+          path: |
+            target/cargo-test-${{ matrix.profile }}.json
+            target/${{ matrix.profile }}-junit.xml
+          if-no-files-found: ignore
+      - name: Upload junit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.profile }}
+          path: target/${{ matrix.profile }}-junit.xml
+          if-no-files-found: ignore
       - name: Job summary
         run: |
           {
-            echo "## Test summary";
-            echo "- cargo test --all-features";
+            echo "## Test summary (${{ matrix.profile }})";
+            if [ "${{ matrix.profile }}" = "dev" ]; then
+              echo "- cargo test --all-features --no-fail-fast -- --format json --report-time";
+              echo "- raw log: cargo-test-dev.json";
+              echo "- junit artifact: junit-dev";
+            else
+              echo "- cargo test --all-features --release --no-fail-fast -- --format json --report-time";
+              echo "- raw log: cargo-test-release.json";
+              echo "- junit artifact: junit-release";
+            fi;
           } >> "$GITHUB_STEP_SUMMARY"
 
   governance-build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-/target/
-**/target/
-Cargo.lock
-**/*.rs.bk
-.DS_Store
-/.idea/
-/.vscode/
-/dist/
-/node_modules/
+/target
+/xtask/target
+/tests/output
+/coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "crates/llmctx"
+    "crates/llmctx",
+    "xtask"
 ]
 resolver = "2"
 
@@ -39,5 +40,8 @@ serde_yaml = "0.9"
 dirs-next = "2"
 once_cell = "1"
 tempfile = "3"
+insta = { version = "1", features = ["glob"] }
+assert_cmd = "2"
+predicates = "3"
 time = { version = "0.3", features = ["formatting", "macros"] }
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Session state (tree filter, focused file, selections, and model override) is aut
 - `cargo test --all-features`
 - `cargo build --workspace --release`
 
-Refer to `docs/ci-governance.md` and `docs/linting.md` for governance details and lint troubleshooting tips.
+Refer to `docs/ci-governance.md`, `docs/linting.md`, and `docs/testing.md` for governance details, lint troubleshooting, and test strategy.
 
 ## Configuration
 llmctx loads settings from the following layers (later entries override earlier ones):

--- a/crates/llmctx/Cargo.toml
+++ b/crates/llmctx/Cargo.toml
@@ -35,3 +35,6 @@ dirs-next.workspace = true
 once_cell.workspace = true
 tempfile.workspace = true
 time = { version = "0.3", features = ["formatting", "macros"] }
+insta.workspace = true
+assert_cmd.workspace = true
+predicates.workspace = true

--- a/crates/llmctx/tests/preview_snapshot.rs
+++ b/crates/llmctx/tests/preview_snapshot.rs
@@ -1,0 +1,11 @@
+use insta::assert_snapshot;
+
+#[test]
+fn preview_default_renders() {
+    let rendered = "```
+fn main() {
+    println!(\"hello\");
+}
+```";
+    assert_snapshot!("preview_default", rendered);
+}

--- a/crates/llmctx/tests/snapshots/preview_snapshot__preview_default.snap
+++ b/crates/llmctx/tests/snapshots/preview_snapshot__preview_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/llmctx/tests/preview_snapshot.rs
+expression: rendered
+---
+```
+fn main() {
+    println!("hello");
+}
+```

--- a/docs/ci-governance.md
+++ b/docs/ci-governance.md
@@ -16,7 +16,7 @@ The workflow name is `CI`. It contains the following stages, executed as separat
 | Job | Purpose | Trigger | Required Status |
 | --- | --- | --- | --- |
 | `governance-lint` | Formatting and Clippy linting | PRs, pushes to `main` | Required |
-| `governance-test` | Unit and integration tests | PRs, pushes to `main` | Required |
+| `governance-test` | Unit & integration tests (dev + release) | PRs, pushes to `main` | Required |
 | `governance-build` | Verifies release build compiles | PRs, pushes to `main` | Required |
 | `governance-security` | Security placeholder (cargo audit, SBOM) | PRs, pushes to `main` | Required once tooling lands |
 
@@ -30,9 +30,10 @@ The workflow is defined in `.github/workflows/ci.yml` and leverages a reusable s
 - Fails fast so contributors address style issues before functional failures.
 
 **governance-test**
-- Executes `cargo test --all-features`.
-- Emits a summary with total tests executed and runtime to monitor flakiness.
-- Future scope: split into unit/integration matrices when runtime requires.
+- Executes a matrix across debug (`cargo test --all-features --no-fail-fast`) and release (`cargo test --all-features --release --no-fail-fast`) profiles.
+- Captures JSON output and converts it with `cargo2junit`, uploading artifacts for dashboards or IDE consumption.
+- Archives raw logs when failures occur and prepares scratch fixtures under `target/test-fixtures/` for integration tests.
+- Future scope: add optional coverage jobs (`cargo tarpaulin`) and OS matrices once runtime analysis justifies it.
 
 **governance-build**
 - Builds optimized binaries via `cargo build --workspace --release`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,63 @@
+# Testing Strategy
+
+This guide explains how llmctx structures automated tests locally and in CI. It also captures the roadmap for coverage tooling so contributors understand the expectations as the suite grows.
+
+## Test Layout
+
+- **Unit tests** live alongside modules using the standard `#[cfg(test)]` convention.
+- **Integration tests** belong in `tests/`. These scenarios can shell out to the binary, exercise the CLI, or mock infrastructure components.
+- **Fixture state** should be created dynamically within each test via helpers. Avoid static files in the repository unless a test specifically covers parsing existing content.
+
+## Local Execution
+
+Run the same commands exercised in CI to ensure green builds:
+
+```sh
+# Fast feedback: debug profile
+cargo test --all-features --no-fail-fast
+
+# Release profile parity with CI (optimisation differences, feature gating)
+cargo test --all-features --release --no-fail-fast
+```
+
+The `--no-fail-fast` flag ensures CI produces the complete failure set; keep it locally when investigating cascades.
+
+### Generating JUnit Reports Locally
+
+CI publishes JUnit XML artifacts for downstream tooling. To reproduce locally:
+
+```sh
+# Install once (skipped if already present)
+cargo install cargo2junit --locked
+
+cargo test --all-features -- --format json --report-time \
+  | cargo2junit > target/dev-junit.xml
+
+cargo test --all-features --release -- --format json --report-time \
+  | cargo2junit > target/release-junit.xml
+```
+
+JUnit files live under `target/` and can be ingested by IDEs or reporting dashboards.
+
+## Integration Test Helpers
+
+The CI workflow creates `target/test-fixtures/default-config.json` before running tests. Use `crate::app::test_support` (or create a helper module) to read from `target/test-fixtures/` so tests can rely on predictable scratch space without polluting the repository.
+
+## Coverage Roadmap
+
+We plan to introduce `cargo tarpaulin` once the test suite stabilises (tracked in Issue #17 follow-ups). The governance doc captures how the coverage stage will integrate with CI, including:
+
+- Running coverage in nightly builds or on-demand via workflow dispatch to keep PRs fast.
+- Publishing coverage summaries as GitHub check annotations and badges.
+- Optionally failing below-threshold coverage once baselines are trusted.
+
+Until then, contributors should keep tests focused, deterministic, and well-documented.
+
+## Failure Investigation Tips
+
+1. Download the `junit-<profile>` and `test-logs-<profile>` artifacts from CI.
+2. Inspect JSON logs for the failing test name and output.
+3. Re-run the failing test with `cargo test <test_path> -- --nocapture`.
+4. Use `RUST_BACKTRACE=1` for additional context.
+
+Keeping tests reliable ensures llmctx remains stable as the feature set grows.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,11 +30,8 @@ CI publishes JUnit XML artifacts for downstream tooling. To reproduce locally:
 # Install once (skipped if already present)
 cargo install cargo2junit --locked
 
-cargo test --all-features -- --format json --report-time \
-  | cargo2junit > target/dev-junit.xml
-
-cargo test --all-features --release -- --format json --report-time \
-  | cargo2junit > target/release-junit.xml
+cargo nextest run --profile ci --workspace --tests --examples --cargo-profile release --message-format libtest-json \
+  | cargo2junit > target/nextest-junit.xml
 ```
 
 JUnit files live under `target/` and can be ingested by IDEs or reporting dashboards.

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1,0 +1,12 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn help_displays_usage() {
+    Command::cargo_bin("llmctx")
+        .expect("binary exists")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Usage"));
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+cargo_metadata = "0.18"
+serde_json = "1"
+toml = "0.8"
+walkdir = "2"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::process::Command;
+
+#[derive(Parser)]
+#[command(author, version, about = "Project automation commands", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run cargo nextest with default configuration
+    Nextest {
+        #[arg(long)]
+        profile: Option<String>,
+        #[arg(long)]
+        release: bool,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Nextest { profile, release } => run_nextest(profile, release)?,
+    }
+    Ok(())
+}
+
+fn run_nextest(profile: Option<String>, release: bool) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("nextest").arg("run");
+    if let Some(profile) = profile {
+        cmd.arg("--profile").arg(profile);
+    }
+    if release {
+        cmd.arg("--release");
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("cargo nextest run failed");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- expand `governance-test` into a matrix covering debug and release profiles with cached tooling
- generate JSON and JUnit artifacts via cargo2junit, surfacing logs when failures occur
- add `docs/testing.md` and update governance/README with guidance and coverage roadmap

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --no-fail-fast`
- `cargo test --all-features --release --no-fail-fast`

Closes #17.